### PR TITLE
Support middleware

### DIFF
--- a/.changeset/quiet-bears-admire.md
+++ b/.changeset/quiet-bears-admire.md
@@ -1,0 +1,5 @@
+---
+"server-act": patch
+---
+
+Support middleware

--- a/examples/nextjs/src/app/actions.ts
+++ b/examples/nextjs/src/app/actions.ts
@@ -3,14 +3,21 @@
 import {serverAct} from 'server-act';
 import {z} from 'zod';
 
+const requestTimeMiddleware = () => {
+  return {
+    requestTime: new Date(),
+  };
+};
+
 export const sayHelloAction = serverAct
+  .middleware(requestTimeMiddleware)
   .input(
     z.object({
       name: z.string().optional(),
     }),
   )
-  .action(async ({input}) => {
-    console.log('Someone say hi from the client!');
+  .action(async ({input, ctx}) => {
+    console.log(`Someone say hi from the client at ${ctx.requestTime.toTimeString()}!`);
     await new Promise((resolve) => setTimeout(resolve, 1000));
     return input.name ? `Hello, ${input.name}!` : 'You need to tell me your name!';
   });


### PR DESCRIPTION
Allow middleware (simple function) to be called before the server action, and its return value will be pass to the server action  as context.