### PR TITLE
Improve action optional param type

### DIFF
--- a/.changeset/rude-ghosts-rhyme.md
+++ b/.changeset/rude-ghosts-rhyme.md
@@ -1,0 +1,5 @@
+---
+"server-act": patch
+---
+
+Improve action optional param type


### PR DESCRIPTION
# Why?
Currently, if you try to pass an action without input into `<form>` action prop, it will throw type error below

![image](https://github.com/chungweileong94/server-act/assets/15154097/50676906-4408-4d85-b595-60bbef6bd8e0)


# After the fix

### Empty input
```ts
const action = serverAct.action(async () => Promise.resolve('bar'));
//     ^?  () => Promise<string>
```

### Non-optional input
```ts
const action = serverAct.input(z.string()).action(async () => Promise.resolve('bar'));
//     ^?  (input: string) => Promise<string>
```

### Optional input
```ts
const action = serverAct.input(z.string().optional()).action(async () => Promise.resolve('bar'));
//     ^?  (input?: string | undefined) => Promise<string>
```