### PR TITLE
Prevent duplicate chaining methods

### DIFF
--- a/.changeset/selfish-kings-cough.md
+++ b/.changeset/selfish-kings-cough.md
@@ -1,0 +1,5 @@
+---
+"server-act": patch
+---
+
+Prevent duplicate chaining methods

--- a/packages/server-act/src/index.ts
+++ b/packages/server-act/src/index.ts
@@ -53,13 +53,19 @@ interface ActionBuilder<TParams extends ActionParams> {
    */
   middleware: <TContext>(
     middleware: () => Promise<TContext> | TContext,
-  ) => ActionBuilder<{ _input: TParams["_input"]; _context: TContext }>;
+  ) => Omit<
+    ActionBuilder<{ _input: TParams["_input"]; _context: TContext }>,
+    "middleware"
+  >;
   /**
    * Input validation for the action.
    */
   input: <TParser extends z.ZodType>(
     input: TParser,
-  ) => ActionBuilder<{ _input: TParser; _context: TParams["_context"] }>;
+  ) => Omit<
+    ActionBuilder<{ _input: TParser; _context: TParams["_context"] }>,
+    "input"
+  >;
   /**
    * Create an action.
    */


### PR DESCRIPTION
Currently, you are able to have duplicate chaining methods like
```ts
serverAct
    .middleware(...)
    .middleware(...)
    .input(...)
    .input(...)
    .action(....)
```
However, the later will override the precedent, which makes people think that we are supporting chaining middlewares #26, yet we are not. So before we have an actual implementation of chaining middleware, we will prevent people from chaining duplicate methods for now.