### PR TITLE
Support middlewate context access in `.input()`

### DIFF
--- a/.changeset/selfish-years-think.md
+++ b/.changeset/selfish-years-think.md
@@ -1,0 +1,5 @@
+---
+"server-act": minor
+---
+
+Support middleware ctx access in `.input()`

--- a/packages/server-act/src/index.test.ts
+++ b/packages/server-act/src/index.test.ts
@@ -212,4 +212,40 @@ describe("formAction", () => {
       foo: ["Required"],
     });
   });
+
+  test("should able to access middleware context", async () => {
+    const action = serverAct
+      .middleware(() => ({ prefix: "best" }))
+      .input(({ ctx }) =>
+        zfd.formData({
+          foo: zfd.text(z.string().transform((v) => `${ctx.prefix}-${v}`)),
+        }),
+      )
+      .formAction(async ({ ctx, formErrors, input }) => {
+        if (formErrors) {
+          return formErrors;
+        }
+        return Promise.resolve(`${input.foo}-${ctx.prefix}-bar`);
+      });
+
+    type State = string | z.ZodError<{ foo: string }>;
+    expectTypeOf(action).toEqualTypeOf<
+      (
+        prevState: State | undefined,
+        formData: FormData,
+      ) => Promise<State | undefined>
+    >();
+    expectTypeOf(action).parameter(1).toHaveProperty("append");
+    expectTypeOf(action).parameter(1).toHaveProperty("delete");
+    expectTypeOf(action).parameter(1).toHaveProperty("get");
+    expectTypeOf(action).parameter(1).toHaveProperty("entries");
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+
+    const formData = new FormData();
+    formData.append("foo", "bar");
+    await expect(action("foo", formData)).resolves.toMatchObject(
+      "best-bar-best-bar",
+    );
+  });
 });

--- a/packages/server-act/src/index.test.ts
+++ b/packages/server-act/src/index.test.ts
@@ -109,6 +109,22 @@ describe("action", () => {
       expect(middlewareSpy).toBeCalledTimes(1);
     });
   });
+
+  test("should able to access middleware context in input", async () => {
+    const action = serverAct
+      .middleware(() => ({ prefix: "best" }))
+      .input(({ ctx }) => z.string().transform((v) => `${ctx.prefix}-${v}`))
+      .action(async ({ ctx, input }) => {
+        return Promise.resolve(`${input}-${ctx.prefix}-bar`);
+      });
+
+    expectTypeOf(action).toEqualTypeOf<(param: string) => Promise<string>>();
+    expectTypeOf(action).parameter(0).toBeString();
+    expectTypeOf(action).returns.resolves.toBeString();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action("foo")).resolves.toBe("best-foo-best-bar");
+  });
 });
 
 describe("formAction", () => {


### PR DESCRIPTION
**What's new**
- Support middleware context access in `.input()`. For example:
```ts
export const sayHelloAction = serverAct
  .middleware(() => {
    const t = getTranslation('App');
    return { t };
  })
  .input(({ ctx }) =>
    zfd.formData({
      name: zfd.text(
        z
          .string({ required_error: ctx.t('error.required') })
          .max(20, { message: ctx.t('error.tooShort') }),
      ),
    }),
  )
  .formAction(async ({ formData, input, formErrors, ctx }) => {
    if (formErrors) {
      return { formData, formErrors: formErrors.formErrors.fieldErrors };
    }
    return { message: `Hello, ${input.name}!` };
  });
```