### PR TITLE
Improved input type infer

### DIFF
--- a/.changeset/angry-chefs-love.md
+++ b/.changeset/angry-chefs-love.md
@@ -1,0 +1,5 @@
+---
+"server-act": minor
+---
+
+Improved input type infer

--- a/packages/server-act/src/index.test.ts
+++ b/packages/server-act/src/index.test.ts
@@ -1,16 +1,18 @@
 import { beforeEach, describe, expect, expectTypeOf, test, vi } from "vitest";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-
 import { serverAct } from ".";
+
+type FormDataLikeInput = {
+  [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;
+  entries(): IterableIterator<[string, FormDataEntryValue]>;
+};
 
 describe("action", () => {
   test("should able to create action without input", async () => {
     const action = serverAct.action(async () => Promise.resolve("bar"));
 
     expectTypeOf(action).toEqualTypeOf<() => Promise<string>>();
-    expectTypeOf(action).parameter(0).toBeUndefined();
-    expectTypeOf(action).returns.resolves.toBeString();
 
     expect(action.constructor.name).toBe("AsyncFunction");
     await expect(action()).resolves.toBe("bar");
@@ -22,8 +24,6 @@ describe("action", () => {
       .action(async () => Promise.resolve("bar"));
 
     expectTypeOf(action).toEqualTypeOf<(input: string) => Promise<string>>();
-    expectTypeOf(action).parameter(0).toBeString();
-    expectTypeOf(action).returns.resolves.toBeString();
 
     expect(action.constructor.name).toBe("AsyncFunction");
     await expect(action("foo")).resolves.toBe("bar");
@@ -35,8 +35,6 @@ describe("action", () => {
       .action(async () => Promise.resolve("bar"));
 
     expectTypeOf(action).toEqualTypeOf<(input: string) => Promise<string>>();
-    expectTypeOf(action).parameter(0).toBeString();
-    expectTypeOf(action).returns.resolves.toBeString();
 
     expect(action.constructor.name).toBe("AsyncFunction");
     await expect(action("foo")).resolves.toBe("bar");
@@ -48,8 +46,6 @@ describe("action", () => {
       .action(async ({ input }) => Promise.resolve(input ?? "bar"));
 
     expectTypeOf(action).toEqualTypeOf<(input?: string) => Promise<string>>();
-    expectTypeOf(action).parameter(0).toBeNullable();
-    expectTypeOf(action).returns.resolves.toBeString();
 
     expect(action.constructor.name).toBe("AsyncFunction");
     await expect(action("foo")).resolves.toBe("foo");
@@ -62,12 +58,25 @@ describe("action", () => {
       .action(async () => Promise.resolve("bar"));
 
     expectTypeOf(action).toEqualTypeOf<(input: string) => Promise<string>>();
-    expectTypeOf(action).parameter(0).toBeString();
-    expectTypeOf(action).returns.resolves.toBeString();
 
     expect(action.constructor.name).toBe("AsyncFunction");
     // @ts-ignore
     await expect(action(1)).rejects.toThrowError();
+  });
+
+  test("should able to infer zod effects input type correctly", async () => {
+    const action = serverAct
+      .input(zfd.formData({ foo: zfd.text() }))
+      .action(async ({ input }) => Promise.resolve(input.foo));
+
+    expectTypeOf(action).toEqualTypeOf<
+      (input: FormData | FormDataLikeInput) => Promise<string>
+    >();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    const formData = new FormData();
+    formData.append("foo", "bar");
+    await expect(action(formData)).resolves.toBe("bar");
   });
 
   describe("middleware should be called once", () => {
@@ -85,7 +94,6 @@ describe("action", () => {
         .action(async ({ ctx }) => Promise.resolve(`${ctx.prefix}-bar`));
 
       expectTypeOf(action).toEqualTypeOf<() => Promise<string>>();
-      expectTypeOf(action).returns.resolves.toBeString();
 
       expect(action.constructor.name).toBe("AsyncFunction");
       await expect(action()).resolves.toBe("best-bar");
@@ -101,8 +109,6 @@ describe("action", () => {
         );
 
       expectTypeOf(action).toEqualTypeOf<(param: string) => Promise<string>>();
-      expectTypeOf(action).parameter(0).toBeString();
-      expectTypeOf(action).returns.resolves.toBeString();
 
       expect(action.constructor.name).toBe("AsyncFunction");
       await expect(action("foo")).resolves.toBe("best-foo-bar");
@@ -119,10 +125,9 @@ describe("action", () => {
       });
 
     expectTypeOf(action).toEqualTypeOf<(param: string) => Promise<string>>();
-    expectTypeOf(action).parameter(0).toBeString();
-    expectTypeOf(action).returns.resolves.toBeString();
 
     expect(action.constructor.name).toBe("AsyncFunction");
+
     await expect(action("foo")).resolves.toBe("best-foo-best-bar");
   });
 });
@@ -134,20 +139,13 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: string | undefined,
-        formData: FormData,
+        formData: undefined,
       ) => Promise<string | undefined>
     >();
-    expectTypeOf(action).parameter(0).toEqualTypeOf<string | undefined>();
-    expectTypeOf(action).parameter(1).toHaveProperty("append");
-    expectTypeOf(action).parameter(1).toHaveProperty("delete");
-    expectTypeOf(action).parameter(1).toHaveProperty("get");
-    expectTypeOf(action).parameter(1).toHaveProperty("entries");
-    expectTypeOf(action).returns.resolves.toEqualTypeOf<string | undefined>();
 
     expect(action.constructor.name).toBe("AsyncFunction");
 
-    const formData = new FormData();
-    await expect(action("foo", formData)).resolves.toMatchObject("bar");
+    await expect(action("foo", undefined)).resolves.toMatchObject("bar");
   });
 
   test("should able to create form action with input", async () => {
@@ -158,15 +156,9 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: string | undefined,
-        formData: FormData,
+        formData: FormData | FormDataLikeInput,
       ) => Promise<string | undefined>
     >();
-    expectTypeOf(action).parameter(0).toEqualTypeOf<string | undefined>();
-    expectTypeOf(action).parameter(1).toHaveProperty("append");
-    expectTypeOf(action).parameter(1).toHaveProperty("delete");
-    expectTypeOf(action).parameter(1).toHaveProperty("get");
-    expectTypeOf(action).parameter(1).toHaveProperty("entries");
-    expectTypeOf(action).returns.resolves.toEqualTypeOf<string | undefined>();
 
     expect(action.constructor.name).toBe("AsyncFunction");
 
@@ -193,13 +185,9 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
-        formData: FormData,
+        formData: FormData | FormDataLikeInput,
       ) => Promise<State | undefined>
     >();
-    expectTypeOf(action).parameter(1).toHaveProperty("append");
-    expectTypeOf(action).parameter(1).toHaveProperty("delete");
-    expectTypeOf(action).parameter(1).toHaveProperty("get");
-    expectTypeOf(action).parameter(1).toHaveProperty("entries");
 
     expect(action.constructor.name).toBe("AsyncFunction");
 
@@ -232,13 +220,9 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
-        formData: FormData,
+        formData: FormData | FormDataLikeInput,
       ) => Promise<State | undefined>
     >();
-    expectTypeOf(action).parameter(1).toHaveProperty("append");
-    expectTypeOf(action).parameter(1).toHaveProperty("delete");
-    expectTypeOf(action).parameter(1).toHaveProperty("get");
-    expectTypeOf(action).parameter(1).toHaveProperty("entries");
 
     expect(action.constructor.name).toBe("AsyncFunction");
 

--- a/packages/server-act/src/index.test.ts
+++ b/packages/server-act/src/index.test.ts
@@ -64,19 +64,32 @@ describe("action", () => {
     await expect(action(1)).rejects.toThrowError();
   });
 
-  test("should able to infer zod effects input type correctly", async () => {
+  test("should able to infer zfd input type correctly", async () => {
     const action = serverAct
       .input(zfd.formData({ foo: zfd.text() }))
       .action(async ({ input }) => Promise.resolve(input.foo));
 
     expectTypeOf(action).toEqualTypeOf<
-      (input: FormData | FormDataLikeInput) => Promise<string>
+      (input: FormData | FormDataLikeInput | { foo: string }) => Promise<string>
     >();
 
     expect(action.constructor.name).toBe("AsyncFunction");
     const formData = new FormData();
     formData.append("foo", "bar");
     await expect(action(formData)).resolves.toBe("bar");
+  });
+
+  test("should able to pass object type to zfd input type", async () => {
+    const action = serverAct
+      .input(zfd.formData({ foo: zfd.text() }))
+      .action(async ({ input }) => Promise.resolve(input.foo));
+
+    expectTypeOf(action).toEqualTypeOf<
+      (input: FormData | FormDataLikeInput | { foo: string }) => Promise<string>
+    >();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action({ foo: "bar" })).resolves.toBe("bar");
   });
 
   describe("middleware should be called once", () => {
@@ -156,7 +169,7 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: string | undefined,
-        formData: FormData | FormDataLikeInput,
+        formData: FormData | FormDataLikeInput | { foo: string },
       ) => Promise<string | undefined>
     >();
 
@@ -185,7 +198,7 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
-        formData: FormData | FormDataLikeInput,
+        formData: FormData | FormDataLikeInput | { foo: string },
       ) => Promise<State | undefined>
     >();
 
@@ -199,6 +212,22 @@ describe("formAction", () => {
     expect(result).toHaveProperty("formErrors.fieldErrors", {
       foo: ["Required"],
     });
+  });
+
+  test("should able to pass object type to zfd input type", async () => {
+    const action = serverAct
+      .input(zfd.formData({ foo: zfd.text() }))
+      .formAction(async () => Promise.resolve("bar"));
+
+    expectTypeOf(action).toEqualTypeOf<
+      (
+        prevState: string | undefined,
+        formData: FormData | FormDataLikeInput | { foo: string },
+      ) => Promise<string | undefined>
+    >();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action("foo", { foo: "bar" })).resolves.toBe("bar");
   });
 
   test("should able to access middleware context", async () => {
@@ -220,7 +249,7 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
-        formData: FormData | FormDataLikeInput,
+        formData: FormData | FormDataLikeInput | { foo: string },
       ) => Promise<State | undefined>
     >();
 

--- a/packages/server-act/src/index.ts
+++ b/packages/server-act/src/index.ts
@@ -85,7 +85,11 @@ interface ActionBuilder<TParams extends ActionParams> {
       input: InferInputType<TParams["_input"], "out">;
     }) => Promise<TOutput>,
   ) => SanitizeFunctionParam<
-    (input: InferInputType<TParams["_input"], "in", false>) => Promise<TOutput>
+    (
+      input:
+        | InferInputType<TParams["_input"], "in">
+        | InferInputType<TParams["_input"], "in", false>,
+    ) => Promise<TOutput>
   >;
   /**
    * Create an action for React `useActionState`
@@ -112,7 +116,9 @@ interface ActionBuilder<TParams extends ActionParams> {
     ) => Promise<TState>,
   ) => (
     prevState: TState | TPrevState,
-    formData: InferInputType<TParams["_input"], "in", false>,
+    formData:
+      | InferInputType<TParams["_input"], "in">
+      | InferInputType<TParams["_input"], "in", false>,
   ) => Promise<TState | TPrevState>;
 }
 // biome-ignore lint/suspicious/noExplicitAny: Intended


### PR DESCRIPTION
Previously code like this
```ts
const action = serverAct
      .input(zfd.formData({ name: zfd.text() }))
      .action(async () => {});
```
will be inferred as `(param: { name: string }) => Promise<void>`, usable, but incorrect input type.

Now the input type will be inferred correctly as
```ts
(param: FormData | FormDataLikeInput | { name: string }) => Promise<void>
```