### PR TITLE
Support Standard Schema

### DIFF
--- a/.changeset/tough-foxes-carry.md
+++ b/.changeset/tough-foxes-carry.md
@@ -10,3 +10,4 @@ Breaking changes:
 
 - Minimum required version of Zod is now `^3.24.0`.
 - `formErrors` in `formAction` will now return `{ messages: string[]; fieldErrors: Record<string, string[]> }` instead of `ZodError`.
+- You can no longer use an object as input if you are using `zfd.formData` from `zod-form-data`.

--- a/.changeset/tough-foxes-carry.md
+++ b/.changeset/tough-foxes-carry.md
@@ -1,0 +1,12 @@
+---
+"server-act": minor
+---
+
+Support [Standard Schema](https://standardschema.dev/)!
+
+You can now use any validation library that supports Standard Schema.
+
+Breaking changes:
+
+- Minimum required version of Zod is now `^3.24.0`.
+- `formErrors` in `formAction` will now return `{ messages: string[]; fieldErrors: Record<string, string[]> }` instead of `ZodError`.

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -13,7 +13,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "server-act": "workspace:*",
-    "zod": "^3.22.2",
+    "zod": "^3.24.2",
     "zod-form-data": "^2.0.2"
   },
   "devDependencies": {

--- a/examples/nextjs/src/app/form-action/actions.ts
+++ b/examples/nextjs/src/app/form-action/actions.ts
@@ -23,7 +23,7 @@ export const sayHelloAction = serverAct
   )
   .formAction(async ({ formData, input, formErrors, ctx }) => {
     if (formErrors) {
-      return { formData, formErrors: formErrors.formErrors.fieldErrors };
+      return { formData, formErrors: formErrors.fieldErrors };
     }
 
     console.log(

--- a/packages/server-act/package.json
+++ b/packages/server-act/package.json
@@ -50,6 +50,7 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.0",
+    "valibot": "^1.0.0",
     "zod": "^3.24.0"
   },
   "peerDependenciesMeta": {
@@ -58,11 +59,15 @@
     },
     "zod": {
       "optional": true
+    },
+    "valibot": {
+      "optional": true
     }
   },
   "devDependencies": {
     "bunchee": "^6.2.0",
     "typescript": "^5.6.3",
+    "valibot": "1.0.0-rc.0",
     "zod": "^3.24.2",
     "zod-form-data": "^2.0.2"
   }

--- a/packages/server-act/package.json
+++ b/packages/server-act/package.json
@@ -44,19 +44,26 @@
     "server action",
     "action"
   ],
-  "devDependencies": {
-    "bunchee": "^6.2.0",
-    "typescript": "^5.6.3",
-    "zod": "^3.22.2",
-    "zod-form-data": "^2.0.2"
+  "dependencies": {
+    "@standard-schema/spec": "^1.0.0",
+    "@standard-schema/utils": "^0.3.0"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0",
-    "zod": "^3.22.2"
+    "zod": "^3.24.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
       "optional": true
+    },
+    "zod": {
+      "optional": true
     }
+  },
+  "devDependencies": {
+    "bunchee": "^6.2.0",
+    "typescript": "^5.6.3",
+    "zod": "^3.24.2",
+    "zod-form-data": "^2.0.2"
   }
 }

--- a/packages/server-act/src/index.test.ts
+++ b/packages/server-act/src/index.test.ts
@@ -70,26 +70,13 @@ describe("action", () => {
       .action(async ({ input }) => Promise.resolve(input.foo));
 
     expectTypeOf(action).toEqualTypeOf<
-      (input: FormData | FormDataLikeInput | { foo: string }) => Promise<string>
+      (input: FormData | FormDataLikeInput) => Promise<string>
     >();
 
     expect(action.constructor.name).toBe("AsyncFunction");
     const formData = new FormData();
     formData.append("foo", "bar");
     await expect(action(formData)).resolves.toBe("bar");
-  });
-
-  test("should able to pass object type to zfd input type", async () => {
-    const action = serverAct
-      .input(zfd.formData({ foo: zfd.text() }))
-      .action(async ({ input }) => Promise.resolve(input.foo));
-
-    expectTypeOf(action).toEqualTypeOf<
-      (input: FormData | FormDataLikeInput | { foo: string }) => Promise<string>
-    >();
-
-    expect(action.constructor.name).toBe("AsyncFunction");
-    await expect(action({ foo: "bar" })).resolves.toBe("bar");
   });
 
   describe("middleware should be called once", () => {
@@ -169,7 +156,7 @@ describe("formAction", () => {
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: string | undefined,
-        formData: FormData | FormDataLikeInput | { foo: string },
+        formData: FormData | FormDataLikeInput,
       ) => Promise<string | undefined>
     >();
 
@@ -194,11 +181,13 @@ describe("formAction", () => {
         return Promise.resolve("bar");
       });
 
-    type State = string | z.ZodError<{ foo: string }>;
+    type State =
+      | string
+      | { messages: string[]; fieldErrors: Record<string, string[]> };
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
-        formData: FormData | FormDataLikeInput | { foo: string },
+        formData: FormData | FormDataLikeInput,
       ) => Promise<State | undefined>
     >();
 
@@ -208,26 +197,7 @@ describe("formAction", () => {
     formData.append("bar", "foo");
 
     const result = await action("foo", formData);
-    expect(result).toBeInstanceOf(z.ZodError);
-    expect(result).toHaveProperty("formErrors.fieldErrors", {
-      foo: ["Required"],
-    });
-  });
-
-  test("should able to pass object type to zfd input type", async () => {
-    const action = serverAct
-      .input(zfd.formData({ foo: zfd.text() }))
-      .formAction(async () => Promise.resolve("bar"));
-
-    expectTypeOf(action).toEqualTypeOf<
-      (
-        prevState: string | undefined,
-        formData: FormData | FormDataLikeInput | { foo: string },
-      ) => Promise<string | undefined>
-    >();
-
-    expect(action.constructor.name).toBe("AsyncFunction");
-    await expect(action("foo", { foo: "bar" })).resolves.toBe("bar");
+    expect(result).toHaveProperty("fieldErrors.foo", ["Required"]);
   });
 
   test("should able to access middleware context", async () => {
@@ -245,11 +215,13 @@ describe("formAction", () => {
         return Promise.resolve(`${input.foo}-${ctx.prefix}-bar`);
       });
 
-    type State = string | z.ZodError<{ foo: string }>;
+    type State =
+      | string
+      | { messages: string[]; fieldErrors: Record<string, string[]> };
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
-        formData: FormData | FormDataLikeInput | { foo: string },
+        formData: FormData | FormDataLikeInput,
       ) => Promise<State | undefined>
     >();
 

--- a/packages/server-act/src/utils.ts
+++ b/packages/server-act/src/utils.ts
@@ -1,0 +1,35 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { getDotPath } from "@standard-schema/utils";
+
+export async function standardValidate<T extends StandardSchemaV1>(
+  schema: T,
+  input: StandardSchemaV1.InferInput<T>,
+): Promise<
+  StandardSchemaV1.Result<
+    StandardSchemaV1.InferOutput<T> | StandardSchemaV1.FailureResult
+  >
+> {
+  let result = schema["~standard"].validate(input);
+  if (result instanceof Promise) result = await result;
+  return result;
+}
+
+export function getFormErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>) {
+  const messages: string[] = [];
+  const fieldErrors: Record<string, string[]> = {};
+  if (issues) {
+    for (const issue of issues) {
+      const dotPath = getDotPath(issue);
+      if (dotPath) {
+        if (fieldErrors[dotPath]) {
+          fieldErrors[dotPath].push(issue.message);
+        } else {
+          fieldErrors[dotPath] = [issue.message];
+        }
+      } else {
+        messages.push(issue.message);
+      }
+    }
+  }
+  return { messages, fieldErrors };
+}

--- a/packages/server-act/src/utils.ts
+++ b/packages/server-act/src/utils.ts
@@ -17,18 +17,16 @@ export async function standardValidate<T extends StandardSchemaV1>(
 export function getFormErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>) {
   const messages: string[] = [];
   const fieldErrors: Record<string, string[]> = {};
-  if (issues) {
-    for (const issue of issues) {
-      const dotPath = getDotPath(issue);
-      if (dotPath) {
-        if (fieldErrors[dotPath]) {
-          fieldErrors[dotPath].push(issue.message);
-        } else {
-          fieldErrors[dotPath] = [issue.message];
-        }
+  for (const issue of issues) {
+    const dotPath = getDotPath(issue);
+    if (dotPath) {
+      if (fieldErrors[dotPath]) {
+        fieldErrors[dotPath].push(issue.message);
       } else {
-        messages.push(issue.message);
+        fieldErrors[dotPath] = [issue.message];
       }
+    } else {
+      messages.push(issue.message);
     }
   }
   return { messages, fieldErrors };

--- a/packages/server-act/tests/valibot.test.ts
+++ b/packages/server-act/tests/valibot.test.ts
@@ -1,0 +1,192 @@
+import * as v from "valibot";
+import { beforeEach, describe, expect, expectTypeOf, test, vi } from "vitest";
+import { serverAct } from "../src";
+
+describe("action", () => {
+  test("should able to create action with input", async () => {
+    const action = serverAct
+      .input(v.string())
+      .action(async () => Promise.resolve("bar"));
+
+    expectTypeOf(action).toEqualTypeOf<(input: string) => Promise<string>>();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action("foo")).resolves.toBe("bar");
+  });
+
+  test("should able to create action with input and check validation action", async () => {
+    const action = serverAct
+      .input(
+        v.pipe(
+          v.string(),
+          v.check((s) => s.startsWith("f")),
+        ),
+      )
+      .action(async () => Promise.resolve("bar"));
+
+    expectTypeOf(action).toEqualTypeOf<(input: string) => Promise<string>>();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action("foo")).resolves.toBe("bar");
+  });
+
+  test("should able to create action with optional input", async () => {
+    const action = serverAct
+      .input(v.optional(v.string()))
+      .action(async ({ input }) => Promise.resolve(input ?? "bar"));
+
+    expectTypeOf(action).toEqualTypeOf<(input?: string) => Promise<string>>();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action("foo")).resolves.toBe("foo");
+    await expect(action()).resolves.toBe("bar");
+  });
+
+  test("should throw error if the input is invalid", async () => {
+    const action = serverAct
+      .input(v.string())
+      .action(async () => Promise.resolve("bar"));
+
+    expectTypeOf(action).toEqualTypeOf<(input: string) => Promise<string>>();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    // @ts-ignore
+    await expect(action(1)).rejects.toThrowError();
+  });
+
+  describe("middleware should be called once", () => {
+    const middlewareSpy = vi.fn(() => {
+      return { prefix: "best" };
+    });
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test("without input", async () => {
+      const action = serverAct
+        .middleware(middlewareSpy)
+        .action(async ({ ctx }) => Promise.resolve(`${ctx.prefix}-bar`));
+
+      expectTypeOf(action).toEqualTypeOf<() => Promise<string>>();
+
+      expect(action.constructor.name).toBe("AsyncFunction");
+      await expect(action()).resolves.toBe("best-bar");
+      expect(middlewareSpy).toBeCalledTimes(1);
+    });
+
+    test("with input", async () => {
+      const action = serverAct
+        .middleware(middlewareSpy)
+        .input(v.string())
+        .action(async ({ ctx, input }) =>
+          Promise.resolve(`${ctx.prefix}-${input}-bar`),
+        );
+
+      expectTypeOf(action).toEqualTypeOf<(param: string) => Promise<string>>();
+
+      expect(action.constructor.name).toBe("AsyncFunction");
+      await expect(action("foo")).resolves.toBe("best-foo-bar");
+      expect(middlewareSpy).toBeCalledTimes(1);
+    });
+  });
+
+  test("should able to access middleware context in input", async () => {
+    const action = serverAct
+      .middleware(() => ({ prefix: "best" }))
+      .input(({ ctx }) =>
+        v.pipe(
+          v.string(),
+          v.transform((v) => `${ctx.prefix}-${v}`),
+        ),
+      )
+      .action(async ({ ctx, input }) => {
+        return Promise.resolve(`${input}-${ctx.prefix}-bar`);
+      });
+
+    expectTypeOf(action).toEqualTypeOf<(param: string) => Promise<string>>();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+
+    await expect(action("foo")).resolves.toBe("best-foo-best-bar");
+  });
+});
+
+describe("formAction", () => {
+  test("should able to create form action with input", async () => {
+    const action = serverAct
+      .input(v.object({ foo: v.string() }))
+      .formAction(async () => Promise.resolve("bar"));
+
+    expectTypeOf(action).toEqualTypeOf<
+      (
+        prevState: string | undefined,
+        formData: { foo: string },
+      ) => Promise<string | undefined>
+    >();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action("foo", { foo: "bar" })).resolves.toMatchObject("bar");
+  });
+
+  test("should return form errors if the input is invalid", async () => {
+    const action = serverAct
+      .input(v.object({ foo: v.string() }))
+      .formAction(async ({ formErrors }) => {
+        if (formErrors) {
+          return formErrors;
+        }
+        return Promise.resolve("bar");
+      });
+
+    type State =
+      | string
+      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    expectTypeOf(action).toEqualTypeOf<
+      (
+        prevState: State | undefined,
+        formData: { foo: string },
+      ) => Promise<State | undefined>
+    >();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+
+    // @ts-expect-error
+    const result = await action("foo", { bar: "foo" });
+    expect(result).toHaveProperty("fieldErrors.foo");
+  });
+
+  test("should able to access middleware context", async () => {
+    const action = serverAct
+      .middleware(() => ({ prefix: "best" }))
+      .input(({ ctx }) =>
+        v.object({
+          foo: v.pipe(
+            v.string(),
+            v.transform((v) => `${ctx.prefix}-${v}`),
+          ),
+        }),
+      )
+      .formAction(async ({ ctx, formErrors, input }) => {
+        if (formErrors) {
+          return formErrors;
+        }
+        return Promise.resolve(`${input.foo}-${ctx.prefix}-bar`);
+      });
+
+    type State =
+      | string
+      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    expectTypeOf(action).toEqualTypeOf<
+      (
+        prevState: State | undefined,
+        formData: { foo: string },
+      ) => Promise<State | undefined>
+    >();
+
+    expect(action.constructor.name).toBe("AsyncFunction");
+    await expect(action("foo", { foo: "bar" })).resolves.toMatchObject(
+      "best-bar-best-bar",
+    );
+  });
+});

--- a/packages/server-act/tests/zod.test.ts
+++ b/packages/server-act/tests/zod.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, expectTypeOf, test, vi } from "vitest";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { serverAct } from ".";
+import { serverAct } from "../src";
 
 type FormDataLikeInput = {
   [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
+      valibot:
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(typescript@5.6.3)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -2579,6 +2582,14 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.0.0-rc.0:
+    resolution: {integrity: sha512-9ZUrOXOejY/WaIn8p0Z469R1qBAwNJeqq8jzOIDsl1qR8gqtObHQmyHLFli0UCkcGiTco5kH6/KPLWsTWE9b2g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -5210,6 +5221,10 @@ snapshots:
       picocolors: 1.0.1
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.0.0-rc.0(typescript@5.6.3):
+    optionalDependencies:
+      typescript: 5.6.3
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,11 +45,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server-act
       zod:
-        specifier: ^3.22.2
-        version: 3.22.2
+        specifier: ^3.24.2
+        version: 3.24.2
       zod-form-data:
         specifier: ^2.0.2
-        version: 2.0.2(zod@3.22.2)
+        version: 2.0.2(zod@3.24.2)
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -74,6 +74,13 @@ importers:
         version: 5.6.3
 
   packages/server-act:
+    dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
+      '@standard-schema/utils':
+        specifier: ^0.3.0
+        version: 0.3.0
     devDependencies:
       bunchee:
         specifier: ^6.2.0
@@ -82,11 +89,11 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       zod:
-        specifier: ^3.22.2
-        version: 3.22.2
+        specifier: ^3.24.2
+        version: 3.24.2
       zod-form-data:
         specifier: ^2.0.2
-        version: 2.0.2(zod@3.22.2)
+        version: 2.0.2(zod@3.24.2)
 
 packages:
 
@@ -799,6 +806,12 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/core-darwin-arm64@1.10.4':
     resolution: {integrity: sha512-sV/eurLhkjn/197y48bxKP19oqcLydSel42Qsy2zepBltqUx+/zZ8+/IS0Bi7kaWVFxerbW1IPB09uq8Zuvm3g==}
@@ -2726,8 +2739,8 @@ packages:
     peerDependencies:
       zod: '>= 3.11.0'
 
-  zod@3.22.2:
-    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
 
@@ -3352,6 +3365,10 @@ snapshots:
     optional: true
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/core-darwin-arm64@1.10.4':
     optional: true
@@ -5370,8 +5387,8 @@ snapshots:
 
   yocto-queue@1.0.0: {}
 
-  zod-form-data@2.0.2(zod@3.22.2):
+  zod-form-data@2.0.2(zod@3.24.2):
     dependencies:
-      zod: 3.22.2
+      zod: 3.24.2
 
-  zod@3.22.2: {}
+  zod@3.24.2: {}


### PR DESCRIPTION
Support [Standard Schema](https://standardschema.dev/)!

You can now use any validation library that supports Standard Schema.

Breaking changes:

- Minimum required version of Zod is now `^3.24.0`.
- `formErrors` in `formAction` will now return `{ messages: string[]; fieldErrors: Record<string, string[]> }` instead of `ZodError`.
- You can no longer use an object as input if you are using `zfd.formData` from `zod-form-data`.
