### PR TITLE
Typesafe input errors

### DIFF
--- a/.changeset/tidy-pets-care.md
+++ b/.changeset/tidy-pets-care.md
@@ -1,0 +1,7 @@
+---
+"server-act": patch
+---
+
+Improve `stateAction` input error typing by inferring dot-path `fieldErrors` from the schema output shape.
+
+Add an `inputErrorShape` override via `.input<TSchema, TInputErrorShape>(...)` for cases where the UI error paths intentionally differ from the parsed schema output.

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -5,6 +5,9 @@ export default function Home() {
     <main className="flex min-h-screen flex-col items-center justify-center gap-4">
       <Link href="/action">👉 Action Example</Link>
       <Link href="/state-action">👉 State Action Example</Link>
+      <Link href="/state-action-override">
+        👉 State Action with Error Shape Override Example
+      </Link>
     </main>
   );
 }

--- a/examples/nextjs/src/app/state-action-override/_actions.ts
+++ b/examples/nextjs/src/app/state-action-override/_actions.ts
@@ -1,10 +1,6 @@
 "use server";
 
-import {
-  createServerActMiddleware,
-  serverAct,
-  type InputErrors,
-} from "server-act";
+import { createServerActMiddleware, serverAct } from "server-act";
 import { formDataToObject } from "server-act/utils";
 import { z } from "zod";
 
@@ -44,24 +40,12 @@ const signupSchemaWithTransform = signupSchema.transform(
   }),
 );
 
-type SignupState =
-  | {
-      rawInput: FormData;
-      inputErrors: InputErrors<{
-        firstName: string;
-        lastName: string;
-      }>["fieldErrors"];
-    }
-  | {
-      message: string;
-    };
-
 export const sayHelloOverrideAction = serverAct
   .use(requestTimeMiddleware)
   .input<typeof signupSchemaWithTransform, z.output<typeof signupSchema>>(
     signupSchemaWithTransform,
   )
-  .stateAction<SignupState>(async ({ rawInput, input, inputErrors, ctx }) => {
+  .stateAction(async ({ rawInput, input, inputErrors, ctx }) => {
     if (inputErrors) {
       return {
         rawInput,

--- a/examples/nextjs/src/app/state-action-override/_actions.ts
+++ b/examples/nextjs/src/app/state-action-override/_actions.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import {
+  createServerActMiddleware,
+  serverAct,
+  type InputErrors,
+} from "server-act";
+import { formDataToObject } from "server-act/utils";
+import { z } from "zod";
+
+function zodFormData<T extends z.ZodType>(schema: T) {
+  return z.preprocess<Record<string, unknown>, T, FormData>(
+    (v) => formDataToObject(v),
+    schema,
+  );
+}
+
+const requestTimeMiddleware = createServerActMiddleware(({ next }) =>
+  next({
+    ctx: {
+      requestTime: new Date(),
+    },
+  }),
+);
+
+const signupSchema = zodFormData(
+  z.object({
+    firstName: z
+      .string()
+      .min(1, { error: "First name is required" })
+      .max(20, { error: "First name is too long" }),
+    lastName: z
+      .string()
+      .min(1, { error: "Last name is required" })
+      .max(20, { error: "Last name is too long" }),
+  }),
+);
+
+const signupSchemaWithTransform = signupSchema.transform(
+  ({ firstName, lastName }) => ({
+    profile: {
+      fullName: `${firstName} ${lastName}`,
+    },
+  }),
+);
+
+type SignupState =
+  | {
+      rawInput: FormData;
+      inputErrors: InputErrors<{
+        firstName: string;
+        lastName: string;
+      }>["fieldErrors"];
+    }
+  | {
+      message: string;
+    };
+
+export const sayHelloOverrideAction = serverAct
+  .use(requestTimeMiddleware)
+  .input<typeof signupSchemaWithTransform, z.output<typeof signupSchema>>(
+    signupSchemaWithTransform,
+  )
+  .stateAction<SignupState>(async ({ rawInput, input, inputErrors, ctx }) => {
+    if (inputErrors) {
+      return {
+        rawInput,
+        inputErrors: inputErrors.fieldErrors,
+      };
+    }
+
+    console.info(
+      `Someone say hi from the client at ${ctx.requestTime.toTimeString()}!`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return { message: `Hello, ${input.profile.fullName}!` };
+  });

--- a/examples/nextjs/src/app/state-action-override/page.tsx
+++ b/examples/nextjs/src/app/state-action-override/page.tsx
@@ -12,33 +12,29 @@ function SubmitButton() {
       className="rounded-md border-2 border-black bg-red-100 px-4 py-2"
       disabled={status.pending}
     >
-      {status.pending ? "Loading..." : "Say hello with transformed input"}
+      {status.pending ? "Loading..." : "Say hello"}
     </button>
   );
 }
 
 export default function StateActionOverridePage() {
   const [state, dispatch] = useActionState(sayHelloOverrideAction, undefined);
-  const firstName =
-    state && "rawInput" in state
-      ? state.rawInput.get("firstName")?.toString()
-      : undefined;
-  const lastName =
-    state && "rawInput" in state
-      ? state.rawInput.get("lastName")?.toString()
-      : undefined;
+  const firstName = state?.rawInput?.get("firstName")?.toString();
+  const lastName = state?.rawInput?.get("lastName")?.toString();
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <div className="mb-10 max-w-md rounded-md border-2 border-blue-400 bg-blue-100 p-2">
+        <p className="text-sm text-blue-500 [&>code]:rounded-md [&>code]:bg-gray-200 [&>code]:px-1 [&>code]:text-gray-600">
+          This example transforms <code>firstName</code> and{" "}
+          <code>lastName</code> into <code>input.profile.fullName</code>, while
+          keeping <code>inputErrors</code> keyed by the original form fields.
+        </p>
+      </div>
       <form
         action={dispatch}
         className="flex w-full flex-col items-stretch justify-stretch gap-2 md:w-80"
       >
-        <p className="text-sm text-gray-500">
-          This example transforms `firstName` and `lastName` into
-          `input.profile.fullName`, while keeping `inputErrors` keyed by the
-          original form fields.
-        </p>
         <label htmlFor="firstName">First name</label>
         <input
           id="firstName"
@@ -46,13 +42,11 @@ export default function StateActionOverridePage() {
           className="rounded-md border-2 border-black px-4 py-2"
           defaultValue={firstName}
         />
-        {state &&
-          "inputErrors" in state &&
-          state.inputErrors.firstName?.map((error: string) => (
-            <p key={error} className="text-red-500">
-              {error}
-            </p>
-          ))}
+        {state?.inputErrors?.firstName?.map((error: string) => (
+          <p key={error} className="text-red-500">
+            {error}
+          </p>
+        ))}
         <label htmlFor="lastName">Last name</label>
         <input
           id="lastName"
@@ -60,13 +54,11 @@ export default function StateActionOverridePage() {
           className="rounded-md border-2 border-black px-4 py-2"
           defaultValue={lastName}
         />
-        {state &&
-          "inputErrors" in state &&
-          state.inputErrors.lastName?.map((error: string) => (
-            <p key={error} className="text-red-500">
-              {error}
-            </p>
-          ))}
+        {state?.inputErrors?.lastName?.map((error: string) => (
+          <p key={error} className="text-red-500">
+            {error}
+          </p>
+        ))}
         <SubmitButton />
         {state && "message" in state && (
           <p className="text-gray-500">{state.message}</p>

--- a/examples/nextjs/src/app/state-action-override/page.tsx
+++ b/examples/nextjs/src/app/state-action-override/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { sayHelloOverrideAction } from "./_actions";
+
+function SubmitButton() {
+  const status = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="rounded-md border-2 border-black bg-red-100 px-4 py-2"
+      disabled={status.pending}
+    >
+      {status.pending ? "Loading..." : "Say hello with transformed input"}
+    </button>
+  );
+}
+
+export default function StateActionOverridePage() {
+  const [state, dispatch] = useActionState(sayHelloOverrideAction, undefined);
+  const firstName =
+    state && "rawInput" in state
+      ? state.rawInput.get("firstName")?.toString()
+      : undefined;
+  const lastName =
+    state && "rawInput" in state
+      ? state.rawInput.get("lastName")?.toString()
+      : undefined;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <form
+        action={dispatch}
+        className="flex w-full flex-col items-stretch justify-stretch gap-2 md:w-80"
+      >
+        <p className="text-sm text-gray-500">
+          This example transforms `firstName` and `lastName` into
+          `input.profile.fullName`, while keeping `inputErrors` keyed by the
+          original form fields.
+        </p>
+        <label htmlFor="firstName">First name</label>
+        <input
+          id="firstName"
+          name="firstName"
+          className="rounded-md border-2 border-black px-4 py-2"
+          defaultValue={firstName}
+        />
+        {state &&
+          "inputErrors" in state &&
+          state.inputErrors.firstName?.map((error: string) => (
+            <p key={error} className="text-red-500">
+              {error}
+            </p>
+          ))}
+        <label htmlFor="lastName">Last name</label>
+        <input
+          id="lastName"
+          name="lastName"
+          className="rounded-md border-2 border-black px-4 py-2"
+          defaultValue={lastName}
+        />
+        {state &&
+          "inputErrors" in state &&
+          state.inputErrors.lastName?.map((error: string) => (
+            <p key={error} className="text-red-500">
+              {error}
+            </p>
+          ))}
+        <SubmitButton />
+        {state && "message" in state && (
+          <p className="text-gray-500">{state.message}</p>
+        )}
+      </form>
+    </main>
+  );
+}

--- a/packages/server-act/README.md
+++ b/packages/server-act/README.md
@@ -204,11 +204,64 @@ export const sayHelloAction = serverAct
   )
   .stateAction(async ({ rawInput, input, inputErrors, ctx }) => {
     if (inputErrors) {
-      return { rawInput, inputErrors: inputErrors.fieldErrors };
+      return {
+        rawInput,
+        nameErrors: inputErrors.fieldErrors["name"],
+        inputErrors: inputErrors.fieldErrors,
+      };
     }
     return { message: `Hello, ${input.name}!` };
   });
 ```
+
+`inputErrors.fieldErrors` uses flat dot-path keys. The canonical way to read them is bracket access like `fieldErrors["name"]` or `fieldErrors["list.0.foo"]`.
+
+#### Overriding `inputErrorShape`
+
+By default, `stateAction` infers `inputErrors.fieldErrors` from the schema output type. That is usually what you want because it matches the parsed `input`.
+
+Sometimes that is not the right source of truth for your UI though. The common case is a schema that transforms flat form fields into a different parsed shape. In those cases, you can override the error-path source with the second generic on `.input()`.
+
+```ts
+const signupSchema = z
+  .object({
+    firstName: z.string().min(1, { error: "First name is required" }),
+    lastName: z.string().min(1, { error: "Last name is required" }),
+  })
+  .transform(({ firstName, lastName }) => ({
+    profile: {
+      fullName: `${firstName} ${lastName}`,
+    },
+  }));
+
+export const saveProfileAction = serverAct
+  .input<
+    typeof signupSchema,
+    { firstName: string; lastName: string }
+  >(signupSchema)
+  .stateAction(async ({ input, inputErrors }) => {
+    if (inputErrors) {
+      return {
+        firstNameErrors: inputErrors.fieldErrors["firstName"],
+        lastNameErrors: inputErrors.fieldErrors["lastName"],
+      };
+    }
+
+    return {
+      message: `Saved ${input.profile.fullName}`,
+    };
+  });
+```
+
+In that example:
+
+- the submitted fields are `firstName` and `lastName`
+- the parsed `input` is transformed into `{ profile: { fullName: string } }`
+- `rawInput` is still inferred from the schema input type
+- `input` is still inferred from the schema output type
+- only `inputErrors.fieldErrors` changes, so it uses `"firstName"` and `"lastName"` keys instead of the transformed output shape
+
+Use this override when your validation schema and your form/error addressing model intentionally differ.
 
 ## Utilities
 

--- a/packages/server-act/README.md
+++ b/packages/server-act/README.md
@@ -223,22 +223,32 @@ By default, `stateAction` infers `inputErrors.fieldErrors` from the schema outpu
 Sometimes that is not the right source of truth for your UI though. The common case is a schema that transforms flat form fields into a different parsed shape. In those cases, you can override the error-path source with the second generic on `.input()`.
 
 ```ts
-const signupSchema = z
-  .object({
-    firstName: z.string().min(1, { error: "First name is required" }),
-    lastName: z.string().min(1, { error: "Last name is required" }),
-  })
-  .transform(({ firstName, lastName }) => ({
+const signupSchema = zodFormData(
+  z.object({
+    firstName: z
+      .string()
+      .min(1, { error: "First name is required" })
+      .max(20, { error: "First name is too long" }),
+    lastName: z
+      .string()
+      .min(1, { error: "Last name is required" })
+      .max(20, { error: "Last name is too long" }),
+  }),
+);
+
+const signupSchemaWithTransform = signupSchema.transform(
+  ({ firstName, lastName }) => ({
     profile: {
       fullName: `${firstName} ${lastName}`,
     },
-  }));
+  }),
+);
 
 export const saveProfileAction = serverAct
   .input<
-    typeof signupSchema,
-    { firstName: string; lastName: string }
-  >(signupSchema)
+    typeof signupSchemaWithTransform,
+    z.output<typeof signupSchema>
+  >(signupSchemaWithTransform)
   .stateAction(async ({ input, inputErrors }) => {
     if (inputErrors) {
       return {

--- a/packages/server-act/src/index.ts
+++ b/packages/server-act/src/index.ts
@@ -7,6 +7,8 @@ import {
   type UseMiddlewareFunction,
 } from "./internal/middleware";
 import { getInputErrors, standardValidate } from "./internal/schema";
+import type { InferParserType, InputErrors } from "./internal/types";
+export type { InputErrors } from "./internal/types";
 
 const unsetMarker = Symbol("unsetMarker");
 type UnsetMarker = typeof unsetMarker;
@@ -37,19 +39,18 @@ type SanitizeFunctionParam<T extends (param: any) => any> = T extends (
       : (param: P) => R
   : never;
 
-type InferParserType<T, TType extends "in" | "out"> = T extends StandardSchemaV1
-  ? TType extends "in"
-    ? StandardSchemaV1.InferInput<T>
-    : StandardSchemaV1.InferOutput<T>
-  : never;
-
 type InferInputType<T, TType extends "in" | "out"> = T extends UnsetMarker
   ? undefined
   : InferParserType<T, TType>;
 
-interface ActionParams<TInput = unknown, TContext = unknown> {
+interface ActionParams<
+  TInput = unknown,
+  TContext = unknown,
+  TInputErrorShape = unknown,
+> {
   _input: TInput;
   _context: TContext;
+  _inputErrorShape: TInputErrorShape;
 }
 
 interface ActionBuilder<TParams extends ActionParams> {
@@ -71,6 +72,7 @@ interface ActionBuilder<TParams extends ActionParams> {
     _context: TParams["_context"] extends UnsetMarker
       ? TNewContext
       : Prettify<TParams["_context"] & TNewContext>;
+    _inputErrorShape: TParams["_inputErrorShape"];
   }>;
   /**
    * Registers middleware in the action pipeline.
@@ -87,18 +89,26 @@ interface ActionBuilder<TParams extends ActionParams> {
     _context: TParams["_context"] extends UnsetMarker
       ? TNextContext
       : Prettify<NormalizeContext<TParams["_context"]> & TNextContext>;
+    _inputErrorShape: TParams["_inputErrorShape"];
   }>;
   /**
    * Input validation for the action.
    */
-  input: <TParser extends StandardSchemaV1>(
+  input: <
+    TParser extends StandardSchemaV1,
+    TInputErrorShape = InferParserType<TParser, "out">,
+  >(
     input:
       | ((params: {
           ctx: NormalizeContext<TParams["_context"]>;
         }) => Promise<TParser> | TParser)
       | TParser,
   ) => Omit<
-    ActionBuilder<{ _input: TParser; _context: TParams["_context"] }>,
+    ActionBuilder<{
+      _input: TParser;
+      _context: TParams["_context"];
+      _inputErrorShape: TInputErrorShape;
+    }>,
     "input"
   >;
   /**
@@ -125,11 +135,11 @@ interface ActionBuilder<TParams extends ActionParams> {
         } & (
           | {
               input: InferInputType<TParams["_input"], "out">;
-              inputErrors?: undefined;
+              inputErrors: undefined;
             }
           | {
-              input?: undefined;
-              inputErrors: ReturnType<typeof getInputErrors>;
+              input: undefined;
+              inputErrors: InputErrors<TParams["_inputErrorShape"]>;
             }
         )
       >,
@@ -143,7 +153,7 @@ interface ActionBuilder<TParams extends ActionParams> {
 type AnyActionBuilder = ActionBuilder<any>;
 
 // oxlint-disable-next-line typescript/no-explicit-any
-interface ActionBuilderDef<TParams extends ActionParams<any>> {
+interface ActionBuilderDef<TParams extends ActionParams<any, any, any>> {
   input:
     | ((params: {
         ctx: TParams["_context"];
@@ -164,10 +174,12 @@ function createServerActionBuilder(
 ): ActionBuilder<{
   _input: UnsetMarker;
   _context: UnsetMarker;
+  _inputErrorShape: UnsetMarker;
 }> {
   const _def: ActionBuilderDef<{
     _input: StandardSchemaV1;
     _context: undefined;
+    _inputErrorShape: unknown;
   }> = {
     input: undefined,
     middleware: [],
@@ -233,6 +245,7 @@ function createServerActionBuilder(
                 // oxlint-disable-next-line typescript/no-explicit-any
                 prevState: prevState as any,
                 rawInput,
+                input: undefined,
                 inputErrors: getInputErrors(result.issues),
               });
             }
@@ -243,6 +256,7 @@ function createServerActionBuilder(
               rawInput,
               // oxlint-disable-next-line typescript/no-explicit-any
               input: result.value as any,
+              inputErrors: undefined,
             });
           }
           return await action({
@@ -251,6 +265,7 @@ function createServerActionBuilder(
             prevState: prevState as any,
             rawInput,
             input: undefined,
+            inputErrors: undefined,
           });
         });
       };

--- a/packages/server-act/src/index.ts
+++ b/packages/server-act/src/index.ts
@@ -95,7 +95,6 @@ function createServerActionBuilder(
                 // oxlint-disable-next-line typescript/no-explicit-any
                 prevState: prevState as any,
                 rawInput,
-                input: undefined,
                 inputErrors: getInputErrors(result.issues),
               });
             }
@@ -106,7 +105,6 @@ function createServerActionBuilder(
               rawInput,
               // oxlint-disable-next-line typescript/no-explicit-any
               input: result.value as any,
-              inputErrors: undefined,
             });
           }
           return await action({
@@ -115,7 +113,6 @@ function createServerActionBuilder(
             prevState: prevState as any,
             rawInput,
             input: undefined,
-            inputErrors: undefined,
           });
         });
       };

--- a/packages/server-act/src/index.ts
+++ b/packages/server-act/src/index.ts
@@ -2,168 +2,18 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { SchemaError } from "@standard-schema/utils";
 import {
   executeMiddlewares,
-  type LegacyMiddlewareFunction,
   type MiddlewareDef,
   type UseMiddlewareFunction,
 } from "./internal/middleware";
 import { getInputErrors, standardValidate } from "./internal/schema";
-import type { InferParserType, InputErrors } from "./internal/types";
+import {
+  type ActionBuilder,
+  type ActionBuilderDef,
+  type AnyActionBuilder,
+  type AnyActionBuilderDef,
+  type UnsetMarker,
+} from "./internal/types";
 export type { InputErrors } from "./internal/types";
-
-const unsetMarker = Symbol("unsetMarker");
-type UnsetMarker = typeof unsetMarker;
-
-type RemoveUnsetMarker<T> = T extends UnsetMarker ? undefined : T;
-type NormalizeContext<T> =
-  RemoveUnsetMarker<T> extends Record<string, unknown>
-    ? RemoveUnsetMarker<T>
-    : {};
-
-type Equals<X, Y> =
-  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
-    ? true
-    : false;
-
-type Prettify<T> = {
-  [P in keyof T]: T[P];
-} & {};
-
-// oxlint-disable-next-line typescript/no-explicit-any
-type SanitizeFunctionParam<T extends (param: any) => any> = T extends (
-  param: infer P,
-) => infer R
-  ? Equals<P, undefined> extends true
-    ? () => R
-    : Equals<P, P | undefined> extends true
-      ? (param?: P) => R
-      : (param: P) => R
-  : never;
-
-type InferInputType<T, TType extends "in" | "out"> = T extends UnsetMarker
-  ? undefined
-  : InferParserType<T, TType>;
-
-interface ActionParams<
-  TInput = unknown,
-  TContext = unknown,
-  TInputErrorShape = unknown,
-> {
-  _input: TInput;
-  _context: TContext;
-  _inputErrorShape: TInputErrorShape;
-}
-
-interface ActionBuilder<TParams extends ActionParams> {
-  /**
-   * Middleware allows you to run code before the action, its return value will pass as context to the action.
-   *
-   * Chaining multiple middlewares is possible, each middleware receives context from previous middlewares
-   * and returns additional context that gets merged.
-   *
-   * @deprecated Use `.use()` instead.
-   */
-  middleware: <TNewContext>(
-    middleware: LegacyMiddlewareFunction<
-      NormalizeContext<TParams["_context"]>,
-      TNewContext
-    >,
-  ) => ActionBuilder<{
-    _input: TParams["_input"];
-    _context: TParams["_context"] extends UnsetMarker
-      ? TNewContext
-      : Prettify<TParams["_context"] & TNewContext>;
-    _inputErrorShape: TParams["_inputErrorShape"];
-  }>;
-  /**
-   * Registers middleware in the action pipeline.
-   * Call `next()` to continue, optionally passing `ctx` to merge additional
-   * context for downstream middleware and the action handler.
-   */
-  use: <TNextContext extends Record<string, unknown>>(
-    middleware: UseMiddlewareFunction<
-      NormalizeContext<TParams["_context"]>,
-      TNextContext
-    >,
-  ) => ActionBuilder<{
-    _input: TParams["_input"];
-    _context: TParams["_context"] extends UnsetMarker
-      ? TNextContext
-      : Prettify<NormalizeContext<TParams["_context"]> & TNextContext>;
-    _inputErrorShape: TParams["_inputErrorShape"];
-  }>;
-  /**
-   * Input validation for the action.
-   */
-  input: <
-    TParser extends StandardSchemaV1,
-    TInputErrorShape = InferParserType<TParser, "out">,
-  >(
-    input:
-      | ((params: {
-          ctx: NormalizeContext<TParams["_context"]>;
-        }) => Promise<TParser> | TParser)
-      | TParser,
-  ) => Omit<
-    ActionBuilder<{
-      _input: TParser;
-      _context: TParams["_context"];
-      _inputErrorShape: TInputErrorShape;
-    }>,
-    "input"
-  >;
-  /**
-   * Create an action.
-   */
-  action: <TOutput>(
-    action: (params: {
-      ctx: NormalizeContext<TParams["_context"]>;
-      input: InferInputType<TParams["_input"], "out">;
-    }) => Promise<TOutput>,
-  ) => SanitizeFunctionParam<
-    (input: InferInputType<TParams["_input"], "in">) => Promise<TOutput>
-  >;
-  /**
-   * Create an action for React `useActionState`
-   */
-  stateAction: <TState, TPrevState = UnsetMarker>(
-    action: (
-      params: Prettify<
-        {
-          ctx: NormalizeContext<TParams["_context"]>;
-          prevState: RemoveUnsetMarker<TPrevState>;
-          rawInput: InferInputType<TParams["_input"], "in">;
-        } & (
-          | {
-              input: InferInputType<TParams["_input"], "out">;
-              inputErrors: undefined;
-            }
-          | {
-              input: undefined;
-              inputErrors: InputErrors<TParams["_inputErrorShape"]>;
-            }
-        )
-      >,
-    ) => Promise<TState>,
-  ) => (
-    prevState: TState | RemoveUnsetMarker<TPrevState>,
-    input: InferInputType<TParams["_input"], "in">,
-  ) => Promise<TState | RemoveUnsetMarker<TPrevState>>;
-}
-// oxlint-disable-next-line typescript/no-explicit-any
-type AnyActionBuilder = ActionBuilder<any>;
-
-// oxlint-disable-next-line typescript/no-explicit-any
-interface ActionBuilderDef<TParams extends ActionParams<any, any, any>> {
-  input:
-    | ((params: {
-        ctx: TParams["_context"];
-      }) => Promise<TParams["_input"]> | TParams["_input"])
-    | TParams["_input"]
-    | undefined;
-  middleware: MiddlewareDef[];
-}
-// oxlint-disable-next-line typescript/no-explicit-any
-type AnyActionBuilderDef = ActionBuilderDef<any>;
 
 function createNewServerActionBuilder(def: Partial<AnyActionBuilderDef>) {
   return createServerActionBuilder(def);

--- a/packages/server-act/src/internal/types.ts
+++ b/packages/server-act/src/internal/types.ts
@@ -1,0 +1,45 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+type Primitive = bigint | boolean | null | number | string | symbol | undefined;
+
+export type InferParserType<
+  T,
+  TType extends "in" | "out",
+> = T extends StandardSchemaV1
+  ? TType extends "in"
+    ? StandardSchemaV1.InferInput<T>
+    : StandardSchemaV1.InferOutput<T>
+  : never;
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type JoinPath<
+  TPrefix extends string,
+  TSuffix extends string,
+> = `${TPrefix}.${TSuffix}`;
+
+type DotPath<T> =
+  IsAny<T> extends true
+    ? string
+    : unknown extends T
+      ? string
+      : T extends Primitive | Date | File | Blob | FormData | Function
+        ? never
+        : T extends readonly (infer TItem)[]
+          ? `${number}` | JoinPath<`${number}`, DotPath<TItem>>
+          : T extends object
+            ? string extends keyof T
+              ? string
+              : {
+                  [TKey in keyof T & string]:
+                    | TKey
+                    | (DotPath<T[TKey]> extends never
+                        ? never
+                        : JoinPath<TKey, DotPath<T[TKey]>>);
+                }[keyof T & string]
+            : string;
+
+export type InputErrors<TShape> = {
+  messages: string[];
+  fieldErrors: Partial<Record<DotPath<TShape>, string[]>>;
+};

--- a/packages/server-act/src/internal/types.ts
+++ b/packages/server-act/src/internal/types.ts
@@ -1,15 +1,25 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type {
+  LegacyMiddlewareFunction,
+  MiddlewareDef,
+  UseMiddlewareFunction,
+} from "./middleware";
+
+const unsetMarker = Symbol("unsetMarker");
+export type UnsetMarker = typeof unsetMarker;
+
+type RemoveUnsetMarker<T> = T extends UnsetMarker ? undefined : T;
+
+type Equals<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+
+type Prettify<T> = {
+  [P in keyof T]: T[P];
+} & {};
 
 type Primitive = bigint | boolean | null | number | string | symbol | undefined;
-
-export type InferParserType<
-  T,
-  TType extends "in" | "out",
-> = T extends StandardSchemaV1
-  ? TType extends "in"
-    ? StandardSchemaV1.InferInput<T>
-    : StandardSchemaV1.InferOutput<T>
-  : never;
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
@@ -43,3 +53,131 @@ export type InputErrors<TShape> = {
   messages: string[];
   fieldErrors: Partial<Record<DotPath<TShape>, string[]>>;
 };
+
+type NormalizeContext<T> =
+  RemoveUnsetMarker<T> extends Record<string, unknown>
+    ? RemoveUnsetMarker<T>
+    : {};
+
+// oxlint-disable-next-line typescript/no-explicit-any
+type SanitizeFunctionParam<T extends (param: any) => any> = T extends (
+  param: infer P,
+) => infer R
+  ? Equals<P, undefined> extends true
+    ? () => R
+    : Equals<P, P | undefined> extends true
+      ? (param?: P) => R
+      : (param: P) => R
+  : never;
+
+type InferParserType<T, TType extends "in" | "out"> = T extends StandardSchemaV1
+  ? TType extends "in"
+    ? StandardSchemaV1.InferInput<T>
+    : StandardSchemaV1.InferOutput<T>
+  : never;
+
+type InferInputType<T, TType extends "in" | "out"> = T extends UnsetMarker
+  ? undefined
+  : InferParserType<T, TType>;
+
+interface ActionParams<
+  TInput = unknown,
+  TContext = unknown,
+  TInputErrorShape = unknown,
+> {
+  _input: TInput;
+  _context: TContext;
+  _inputErrorShape: TInputErrorShape;
+}
+
+export interface ActionBuilder<TParams extends ActionParams> {
+  middleware: <TNewContext>(
+    middleware: LegacyMiddlewareFunction<
+      NormalizeContext<TParams["_context"]>,
+      TNewContext
+    >,
+  ) => ActionBuilder<{
+    _input: TParams["_input"];
+    _context: TParams["_context"] extends UnsetMarker
+      ? TNewContext
+      : Prettify<TParams["_context"] & TNewContext>;
+    _inputErrorShape: TParams["_inputErrorShape"];
+  }>;
+  use: <TNextContext extends Record<string, unknown>>(
+    middleware: UseMiddlewareFunction<
+      NormalizeContext<TParams["_context"]>,
+      TNextContext
+    >,
+  ) => ActionBuilder<{
+    _input: TParams["_input"];
+    _context: TParams["_context"] extends UnsetMarker
+      ? TNextContext
+      : Prettify<NormalizeContext<TParams["_context"]> & TNextContext>;
+    _inputErrorShape: TParams["_inputErrorShape"];
+  }>;
+  input: <
+    TParser extends StandardSchemaV1,
+    TInputErrorShape = InferParserType<TParser, "out">,
+  >(
+    input:
+      | ((params: {
+          ctx: NormalizeContext<TParams["_context"]>;
+        }) => Promise<TParser> | TParser)
+      | TParser,
+  ) => Omit<
+    ActionBuilder<{
+      _input: TParser;
+      _context: TParams["_context"];
+      _inputErrorShape: TInputErrorShape;
+    }>,
+    "input"
+  >;
+  action: <TOutput>(
+    action: (params: {
+      ctx: NormalizeContext<TParams["_context"]>;
+      input: InferInputType<TParams["_input"], "out">;
+    }) => Promise<TOutput>,
+  ) => SanitizeFunctionParam<
+    (input: InferInputType<TParams["_input"], "in">) => Promise<TOutput>
+  >;
+  stateAction: <TState, TPrevState = UnsetMarker>(
+    action: (
+      params: Prettify<
+        {
+          ctx: NormalizeContext<TParams["_context"]>;
+          prevState: RemoveUnsetMarker<TPrevState>;
+          rawInput: InferInputType<TParams["_input"], "in">;
+        } & (
+          | {
+              input: InferInputType<TParams["_input"], "out">;
+              inputErrors: undefined;
+            }
+          | {
+              input: undefined;
+              inputErrors: InputErrors<TParams["_inputErrorShape"]>;
+            }
+        )
+      >,
+    ) => Promise<TState>,
+  ) => (
+    prevState: TState | RemoveUnsetMarker<TPrevState>,
+    input: InferInputType<TParams["_input"], "in">,
+  ) => Promise<TState | RemoveUnsetMarker<TPrevState>>;
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any
+export type AnyActionBuilder = ActionBuilder<any>;
+
+// oxlint-disable-next-line typescript/no-explicit-any
+export interface ActionBuilderDef<TParams extends ActionParams<any, any, any>> {
+  input:
+    | ((params: {
+        ctx: TParams["_context"];
+      }) => Promise<TParams["_input"]> | TParams["_input"])
+    | TParams["_input"]
+    | undefined;
+  middleware: MiddlewareDef[];
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any
+export type AnyActionBuilderDef = ActionBuilderDef<any>;

--- a/packages/server-act/src/internal/types.ts
+++ b/packages/server-act/src/internal/types.ts
@@ -150,10 +150,10 @@ export interface ActionBuilder<TParams extends ActionParams> {
         } & (
           | {
               input: InferInputType<TParams["_input"], "out">;
-              inputErrors: undefined;
+              inputErrors?: undefined;
             }
           | {
-              input: undefined;
+              input?: undefined;
               inputErrors: InputErrors<TParams["_inputErrorShape"]>;
             }
         )

--- a/packages/server-act/tests/valibot.test.ts
+++ b/packages/server-act/tests/valibot.test.ts
@@ -7,7 +7,7 @@ import {
   test,
   vi,
 } from "vite-plus/test";
-import { createServerActMiddleware, serverAct } from "../src";
+import { createServerActMiddleware, serverAct, type InputErrors } from "../src";
 import { formDataToObject } from "../src/utils";
 
 describe("action", () => {
@@ -169,14 +169,15 @@ describe("stateAction", () => {
       )
       .stateAction(async ({ input, inputErrors }) => {
         if (inputErrors) {
+          expectTypeOf(inputErrors.fieldErrors).toEqualTypeOf<
+            Partial<Record<"foo", string[]>>
+          >();
           return inputErrors;
         }
         return Promise.resolve(input.foo);
       });
 
-    type State =
-      | string
-      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    type State = string | InputErrors<{ foo: string }>;
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
@@ -196,14 +197,15 @@ describe("stateAction", () => {
       .input(v.object({ foo: v.string() }))
       .stateAction(async ({ inputErrors }) => {
         if (inputErrors) {
+          expectTypeOf(inputErrors.fieldErrors).toEqualTypeOf<
+            Partial<Record<"foo", string[]>>
+          >();
           return inputErrors;
         }
         return Promise.resolve("bar");
       });
 
-    type State =
-      | string
-      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    type State = string | InputErrors<{ foo: string }>;
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
@@ -240,9 +242,7 @@ describe("stateAction", () => {
         return Promise.resolve(`${input.foo}-${ctx.prefix}-bar`);
       });
 
-    type State =
-      | string
-      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    type State = string | InputErrors<{ foo: string }>;
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,

--- a/packages/server-act/tests/zod.test.ts
+++ b/packages/server-act/tests/zod.test.ts
@@ -7,7 +7,7 @@ import {
   vi,
 } from "vite-plus/test";
 import { z } from "zod";
-import { createServerActMiddleware, serverAct } from "../src";
+import { createServerActMiddleware, serverAct, type InputErrors } from "../src";
 import { formDataToObject } from "../src/utils";
 
 function zodFormData<T extends z.ZodType>(
@@ -171,14 +171,15 @@ describe("stateAction", () => {
       .input(z.object({ foo: z.string({ error: "Required" }) }))
       .stateAction(async ({ inputErrors }) => {
         if (inputErrors) {
+          expectTypeOf(inputErrors.fieldErrors).toEqualTypeOf<
+            Partial<Record<"foo", string[]>>
+          >();
           return inputErrors;
         }
         return Promise.resolve("bar");
       });
 
-    type State =
-      | string
-      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    type State = string | InputErrors<{ foo: string }>;
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
@@ -204,14 +205,17 @@ describe("stateAction", () => {
       )
       .stateAction(async ({ inputErrors, input }) => {
         if (inputErrors) {
+          expectTypeOf(inputErrors.fieldErrors).toEqualTypeOf<
+            Partial<
+              Record<"list" | `list.${number}` | `list.${number}.foo`, string[]>
+            >
+          >();
           return inputErrors;
         }
         return Promise.resolve(input.list.map((item) => item.foo).join(","));
       });
 
-    type State =
-      | string
-      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    type State = string | InputErrors<{ list: { foo: string }[] }>;
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
@@ -242,14 +246,17 @@ describe("stateAction", () => {
       )
       .stateAction(async ({ inputErrors }) => {
         if (inputErrors) {
+          expectTypeOf(inputErrors.fieldErrors).toEqualTypeOf<
+            Partial<
+              Record<"list" | `list.${number}` | `list.${number}.foo`, string[]>
+            >
+          >();
           return inputErrors;
         }
         return Promise.resolve("bar");
       });
 
-    type State =
-      | string
-      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    type State = string | InputErrors<{ list: { foo: string }[] }>;
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
@@ -287,9 +294,7 @@ describe("stateAction", () => {
         return Promise.resolve(`${input.foo}-${ctx.prefix}-bar`);
       });
 
-    type State =
-      | string
-      | { messages: string[]; fieldErrors: Record<string, string[]> };
+    type State = string | InputErrors<{ foo: string }>;
     expectTypeOf(action).toEqualTypeOf<
       (
         prevState: State | undefined,
@@ -340,5 +345,39 @@ describe("stateAction", () => {
     expect(action.constructor.name).toBe("AsyncFunction");
 
     await expect(action(123, undefined)).resolves.toMatch("foo");
+  });
+
+  test("should allow overriding error path inference without changing input inference", async () => {
+    const schema = zodFormData(
+      z.object({
+        name: z.string(),
+      }),
+    );
+
+    const action = serverAct
+      .input<typeof schema, { profile: { name: string } }>(schema)
+      .stateAction(async ({ rawInput, input, inputErrors }) => {
+        expectTypeOf(rawInput).toEqualTypeOf<FormData>();
+        if (inputErrors) {
+          expectTypeOf(inputErrors.fieldErrors).toEqualTypeOf<
+            Partial<Record<"profile" | "profile.name", string[]>>
+          >();
+          return inputErrors;
+        }
+        expectTypeOf(input).toEqualTypeOf<{ name: string }>();
+        return Promise.resolve(input.name);
+      });
+
+    type State = string | InputErrors<{ profile: { name: string } }>;
+    expectTypeOf(action).toEqualTypeOf<
+      (
+        prevState: State | undefined,
+        input: FormData,
+      ) => Promise<State | undefined>
+    >();
+
+    const formData = new FormData();
+    formData.append("name", "Ada");
+    await expect(action(undefined, formData)).resolves.toBe("Ada");
   });
 });


### PR DESCRIPTION
Improve `stateAction` input error typing by inferring dot-path `fieldErrors` from the schema output shape.

Add an `inputErrorShape` override via `.input<TSchema, TInputErrorShape>(...)` for cases where the UI error paths intentionally differ from the parsed schema output.

Also moved majority of the types into a different file for maintainability.

fix #65 