### PR TITLE
Prevent prototype pollution and silent data loss in formDataToObject

### DIFF
--- a/.changeset/formdata-prototype-pollution.md
+++ b/.changeset/formdata-prototype-pollution.md
@@ -1,0 +1,7 @@
+---
+"server-act": patch
+---
+
+Fix a prototype pollution vulnerability in `formDataToObject`. Form data keys such as `__proto__`, `constructor`, and `prototype` are now rejected instead of being written onto the object prototype.
+
+`formDataToObject` also no longer silently drops values on ambiguous key collisions. Descending into a key that already holds a scalar/`File` value, or overwriting a nested object with a scalar, now throws a descriptive error. Multiple files uploaded under the same key still collapse into an array.

--- a/packages/server-act/src/utils.ts
+++ b/packages/server-act/src/utils.ts
@@ -4,37 +4,65 @@ function isNumberString(str: string) {
   return /^\d+$/.test(str);
 }
 
+/**
+ * Keys that could be used to walk up the prototype chain and pollute
+ * `Object.prototype`. They are never valid form field names, so we reject them.
+ */
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Whether `value` is a plain object (one we created while building the
+ * structure), as opposed to a leaf value such as a `File` or `Blob`.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 function set(
   // oxlint-disable-next-line typescript/no-explicit-any
   obj: Record<string, any>,
   path: readonly string[],
   value: unknown,
 ): void {
+  const key = path[0];
+  assert(key != null);
+
+  if (FORBIDDEN_KEYS.has(key)) {
+    throw new Error(`Unsafe form data key "${key}" is not allowed`);
+  }
+
   if (path.length > 1) {
-    const newPath = [...path];
-    const key = newPath.shift();
-    assert(key != null);
+    const newPath = path.slice(1);
     const nextKey = newPath[0];
     assert(nextKey != null);
 
-    if (!obj[key]) {
+    if (obj[key] === undefined) {
       obj[key] = isNumberString(nextKey) ? [] : {};
     } else if (Array.isArray(obj[key]) && !isNumberString(nextKey)) {
       obj[key] = Object.fromEntries(Object.entries(obj[key]));
+    } else if (!Array.isArray(obj[key]) && !isPlainObject(obj[key])) {
+      throw new Error(
+        `Conflicting form data key "${path.join(".")}": "${key}" is already a value`,
+      );
     }
 
     set(obj[key], newPath, value);
 
     return;
   }
-  const p = path[0];
-  assert(p != null);
-  if (obj[p] === undefined) {
-    obj[p] = value;
-  } else if (Array.isArray(obj[p])) {
-    obj[p].push(value);
+
+  if (obj[key] === undefined) {
+    obj[key] = value;
+  } else if (Array.isArray(obj[key])) {
+    obj[key].push(value);
+  } else if (isPlainObject(obj[key])) {
+    throw new Error(
+      `Conflicting form data key "${key}": already holds a nested object`,
+    );
   } else {
-    obj[p] = [obj[p], value];
+    obj[key] = [obj[key], value];
   }
 }
 

--- a/packages/server-act/tests/utils.test.ts
+++ b/packages/server-act/tests/utils.test.ts
@@ -373,4 +373,91 @@ describe("formDataToObject", () => {
       },
     });
   });
+
+  describe("prototype pollution", () => {
+    test.each(["__proto__", "constructor", "prototype"])(
+      "should reject top-level unsafe key `%s`",
+      (unsafeKey) => {
+        const formData = new FormData();
+        formData.append(unsafeKey, "value");
+
+        expect(() => formDataToObject(formData)).toThrow(
+          `Unsafe form data key "${unsafeKey}" is not allowed`,
+        );
+      },
+    );
+
+    test("should reject unsafe key in nested dot path", () => {
+      const formData = new FormData();
+      formData.append("__proto__.polluted", "yes");
+
+      expect(() => formDataToObject(formData)).toThrow(
+        `Unsafe form data key "__proto__" is not allowed`,
+      );
+    });
+
+    test("should reject unsafe key in the middle of a path", () => {
+      const formData = new FormData();
+      formData.append("user.constructor.prototype.polluted", "yes");
+
+      expect(() => formDataToObject(formData)).toThrow(
+        `Unsafe form data key "constructor" is not allowed`,
+      );
+    });
+
+    test("should not pollute Object.prototype", () => {
+      const formData = new FormData();
+      formData.append("constructor.prototype.polluted", "yes");
+      formData.append("__proto__.polluted", "yes");
+
+      // Both entries throw, but critically nothing leaks onto the prototype.
+      expect(() => formDataToObject(formData)).toThrow();
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+
+  describe("conflicting keys", () => {
+    test("should throw when descending into an existing scalar value", () => {
+      const formData = new FormData();
+      formData.append("a", "x");
+      formData.append("a.b", "y");
+
+      expect(() => formDataToObject(formData)).toThrow(
+        `Conflicting form data key "a.b": "a" is already a value`,
+      );
+    });
+
+    test("should throw when a scalar collides with an existing nested object", () => {
+      const formData = new FormData();
+      formData.append("a.b", "y");
+      formData.append("a", "x");
+
+      expect(() => formDataToObject(formData)).toThrow(
+        `Conflicting form data key "a": already holds a nested object`,
+      );
+    });
+
+    test("should throw when descending into an existing File value", () => {
+      const formData = new FormData();
+      const file = new File(["content"], "test.txt", { type: "text/plain" });
+      formData.append("doc", file);
+      formData.append("doc.name", "renamed");
+
+      expect(() => formDataToObject(formData)).toThrow(
+        `Conflicting form data key "doc.name": "doc" is already a value`,
+      );
+    });
+
+    test("should collapse multiple files under the same key into an array", () => {
+      const formData = new FormData();
+      const file1 = new File(["1"], "a.txt", { type: "text/plain" });
+      const file2 = new File(["2"], "b.txt", { type: "text/plain" });
+      formData.append("files", file1);
+      formData.append("files", file2);
+
+      const result = formDataToObject(formData);
+
+      expect(result).toEqual({ files: [file1, file2] });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`formDataToObject` (from `server-act/utils`) builds a nested object from attacker-controllable `FormData` keys. Two problems:

1. **Prototype pollution (security).** Keys like `__proto__.polluted` or `constructor.prototype.polluted` were walked as normal paths and written through to `Object.prototype`, polluting every object in the process.
2. **Silent data loss.** When a key both held a scalar and was descended into (e.g. `a` and `a.b`), the nested write was silently discarded — no value, no error.

Both are triggerable from untrusted form input inside a server action.

## Changes

- Reject `__proto__`, `constructor`, and `prototype` as path segments (checked at every level of the path), throwing `Unsafe form data key "<key>" is not allowed`.
- Throw a descriptive `Conflicting form data key ...` error on ambiguous collisions instead of dropping data:
  - descending into a key that already holds a scalar/`File`
  - overwriting an existing nested object with a scalar
- Use `obj[key] === undefined` (was a truthiness check) so a legitimate falsy leaf like `""` is no longer silently overwritten.
- Collision detection uses a **plain-object** check, so `File`/`Blob` stay leaf values — multiple files under one key still collapse into an array (`{ files: [file1, file2] }`).