### PR TITLE
[codex] Guard middleware next against repeated calls

### DIFF
--- a/.changeset/clean-middleware-next.md
+++ b/.changeset/clean-middleware-next.md
@@ -1,0 +1,7 @@
+---
+"server-act": patch
+---
+
+Prevent `.use()` middleware from calling `next()` more than once. Repeated calls now throw a clear error instead of re-running downstream middleware or the final action, which helps avoid accidental duplicate side effects.
+
+The legacy `.middleware()` API is also now marked as deprecated, matching the README guidance to use `.use()`.

--- a/packages/server-act/README.md
+++ b/packages/server-act/README.md
@@ -91,6 +91,7 @@ You can chain multiple middlewares by calling `.use(...)` repeatedly.
 
 - Middlewares run in registration order.
 - Each middleware receives the current `ctx` and forwards additions with `next({ ctx })`.
+- Each middleware must call `next()` exactly once and return its result.
 - `next()` can be called without params when nothing needs to be added.
 - `next({ ctx })` shallow-merges the provided keys into the current context.
 - Later middleware values override earlier values for the same key.

--- a/packages/server-act/src/internal/middleware.test.ts
+++ b/packages/server-act/src/internal/middleware.test.ts
@@ -221,6 +221,27 @@ describe("executeMiddlewares", () => {
     ).rejects.toThrow(".use() middleware must call next()");
   });
 
+  test("throws when a `.use()` middleware calls next() more than once", async () => {
+    const terminal = vi.fn(returnContext);
+
+    await expect(
+      executeMiddlewares(
+        [
+          {
+            kind: "use",
+            middleware: async ({ next }) => {
+              await next();
+              return await next();
+            },
+          },
+        ],
+        undefined,
+        terminal,
+      ),
+    ).rejects.toThrow(".use() middleware must call next() only once");
+    expect(terminal).toHaveBeenCalledTimes(1);
+  });
+
   test("propagates thrown errors and stops subsequent middleware execution", async () => {
     const neverCalled = vi.fn(() => ({ skipped: true }));
 

--- a/packages/server-act/src/internal/middleware.ts
+++ b/packages/server-act/src/internal/middleware.ts
@@ -71,6 +71,9 @@ export async function executeMiddlewares<TOutput>(
       next: async <TAddedContext extends MiddlewareContext = {}>(opts?: {
         ctx?: TAddedContext;
       }) => {
+        if (nextCalled) {
+          throw new Error(".use() middleware must call next() only once");
+        }
         nextCalled = true;
         const nextCtx = opts?.ctx ? { ...ctx, ...opts.ctx } : ctx;
         return (await executeAt(

--- a/packages/server-act/src/internal/types.ts
+++ b/packages/server-act/src/internal/types.ts
@@ -91,6 +91,9 @@ interface ActionParams<
 }
 
 export interface ActionBuilder<TParams extends ActionParams> {
+  /**
+   * @deprecated Use `.use()` instead.
+   */
   middleware: <TNewContext>(
     middleware: LegacyMiddlewareFunction<
       NormalizeContext<TParams["_context"]>,


### PR DESCRIPTION
## Summary

- Prevent `.use()` middleware from calling `next()` more than once, avoiding repeated downstream middleware or final action execution.
- Add a regression test and document the exact-once middleware contract.
- Mark the legacy `.middleware()` API as deprecated in TypeScript declarations.
- Add a patch changeset for the middleware hardening change.

## Why

Server actions often perform side effects. A middleware that accidentally called `next()` more than once could invoke downstream work multiple times, which is surprising and potentially unsafe.

## Validation

- `pnpm --filter server-act test`
- `pnpm check`
- `pnpm changeset status --since=main`