### PR TITLE
[codex] Precompile middleware runners

### DIFF
--- a/.changeset/quiet-middleware-runner.md
+++ b/.changeset/quiet-middleware-runner.md
@@ -1,0 +1,5 @@
+---
+"server-act": patch
+---
+
+Precompile middleware runners when actions are created and skip middleware execution machinery for actions without middleware. This reduces per-call overhead while preserving existing middleware behavior.

--- a/packages/server-act/src/index.ts
+++ b/packages/server-act/src/index.ts
@@ -1,7 +1,7 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { SchemaError } from "@standard-schema/utils";
 import {
-  executeMiddlewares,
+  createMiddlewareRunner,
   type MiddlewareDef,
   type UseMiddlewareFunction,
 } from "./internal/middleware";
@@ -57,61 +57,83 @@ function createServerActionBuilder(
     input: (input) =>
       createNewServerActionBuilder({ ..._def, input }) as AnyActionBuilder,
     action: (action) => {
+      const middlewareRunner =
+        _def.middleware.length > 0
+          ? createMiddlewareRunner(_def.middleware)
+          : undefined;
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const runAction = async (ctx: Record<string, unknown>, input?: any) => {
+        if (_def.input) {
+          const inputSchema =
+            typeof _def.input === "function"
+              ? await _def.input({ ctx: ctx as never })
+              : _def.input;
+          const result = await standardValidate(inputSchema, input);
+          if (result.issues) {
+            throw new SchemaError(result.issues);
+          }
+          // oxlint-disable-next-line typescript/no-explicit-any
+          return await action({ ctx, input: result.value as any });
+        }
+        return await action({ ctx, input: undefined });
+      };
+
       // oxlint-disable-next-line typescript/no-explicit-any
       return async (input?: any) => {
-        return await executeMiddlewares(_def.middleware, {}, async (ctx) => {
-          if (_def.input) {
-            const inputSchema =
-              typeof _def.input === "function"
-                ? await _def.input({ ctx: ctx as never })
-                : _def.input;
-            const result = await standardValidate(inputSchema, input);
-            if (result.issues) {
-              throw new SchemaError(result.issues);
-            }
-            // oxlint-disable-next-line typescript/no-explicit-any
-            return await action({ ctx, input: result.value as any });
-          }
-          return await action({ ctx, input: undefined });
-        });
+        if (middlewareRunner) {
+          return await middlewareRunner({}, (ctx) => runAction(ctx, input));
+        }
+        return await runAction({}, input);
       };
     },
     stateAction: (action) => {
-      // oxlint-disable-next-line typescript/no-explicit-any
-      return async (prevState, rawInput?: any) => {
-        return await executeMiddlewares(_def.middleware, {}, async (ctx) => {
-          if (_def.input) {
-            const inputSchema =
-              typeof _def.input === "function"
-                ? await _def.input({ ctx: ctx as never })
-                : _def.input;
-            const result = await standardValidate(inputSchema, rawInput);
-            if (result.issues) {
-              return await action({
-                ctx,
-                // oxlint-disable-next-line typescript/no-explicit-any
-                prevState: prevState as any,
-                rawInput,
-                inputErrors: getInputErrors(result.issues),
-              });
-            }
+      const middlewareRunner =
+        _def.middleware.length > 0
+          ? createMiddlewareRunner(_def.middleware)
+          : undefined;
+      const runStateAction = async (
+        ctx: Record<string, unknown>,
+        prevState: unknown,
+        rawInput?: unknown,
+      ) => {
+        if (_def.input) {
+          const inputSchema =
+            typeof _def.input === "function"
+              ? await _def.input({ ctx: ctx as never })
+              : _def.input;
+          const result = await standardValidate(inputSchema, rawInput);
+          if (result.issues) {
             return await action({
               ctx,
-              // oxlint-disable-next-line typescript/no-explicit-any
-              prevState: prevState as any,
-              rawInput,
-              // oxlint-disable-next-line typescript/no-explicit-any
-              input: result.value as any,
+              prevState: prevState as never,
+              rawInput: rawInput as never,
+              inputErrors: getInputErrors(result.issues),
             });
           }
           return await action({
             ctx,
+            prevState: prevState as never,
+            rawInput: rawInput as never,
             // oxlint-disable-next-line typescript/no-explicit-any
-            prevState: prevState as any,
-            rawInput,
-            input: undefined,
+            input: result.value as any,
           });
+        }
+        return await action({
+          ctx,
+          prevState: prevState as never,
+          rawInput: rawInput as never,
+          input: undefined,
         });
+      };
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      return async (prevState, rawInput?: any) => {
+        if (middlewareRunner) {
+          return await middlewareRunner({}, (ctx) =>
+            runStateAction(ctx, prevState, rawInput),
+          );
+        }
+        return await runStateAction({}, prevState, rawInput);
       };
     },
   };

--- a/packages/server-act/src/internal/middleware.test.ts
+++ b/packages/server-act/src/internal/middleware.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test, vi } from "vite-plus/test";
-import { executeMiddlewares, type MiddlewareResult } from "./middleware";
+import {
+  createMiddlewareRunner,
+  executeMiddlewares,
+  type MiddlewareResult,
+} from "./middleware";
 
 async function returnContext(ctx: Record<string, unknown>) {
   return ctx;
@@ -284,5 +288,37 @@ describe("executeMiddlewares", () => {
         returnContext,
       ),
     ).rejects.toThrow("reject boom");
+  });
+});
+
+describe("createMiddlewareRunner", () => {
+  test("normalizes context when no middlewares are registered", async () => {
+    const runner = createMiddlewareRunner([]);
+    const initialCtx = { a: 1 };
+
+    const result = await runner(initialCtx, returnContext);
+
+    expect(result).toEqual({ a: 1 });
+    expect(result).not.toBe(initialCtx);
+  });
+
+  test("can be reused across calls with isolated next() state", async () => {
+    const useMiddleware = vi.fn(({ ctx, next }) =>
+      next({ ctx: { count: Number(ctx.count) + 1 } }),
+    );
+    const runner = createMiddlewareRunner([
+      {
+        kind: "use",
+        middleware: useMiddleware,
+      },
+    ]);
+
+    await expect(runner({ count: 1 }, returnContext)).resolves.toEqual({
+      count: 2,
+    });
+    await expect(runner({ count: 10 }, returnContext)).resolves.toEqual({
+      count: 11,
+    });
+    expect(useMiddleware).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/server-act/src/internal/middleware.test.ts
+++ b/packages/server-act/src/internal/middleware.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vite-plus/test";
 import {
   createMiddlewareRunner,
-  executeMiddlewares,
+  type MiddlewareDef,
   type MiddlewareResult,
 } from "./middleware";
 
@@ -9,17 +9,25 @@ async function returnContext(ctx: Record<string, unknown>) {
   return ctx;
 }
 
-describe("executeMiddlewares", () => {
+async function runMiddlewares<TOutput>(
+  middlewares: readonly MiddlewareDef[],
+  initialCtx: unknown,
+  terminal: (ctx: Record<string, unknown>) => Promise<TOutput>,
+) {
+  return await createMiddlewareRunner(middlewares)(initialCtx, terminal);
+}
+
+describe("createMiddlewareRunner", () => {
   test("returns empty object with no middlewares and no initial context", async () => {
-    await expect(
-      executeMiddlewares([], undefined, returnContext),
-    ).resolves.toEqual({});
+    await expect(runMiddlewares([], undefined, returnContext)).resolves.toEqual(
+      {},
+    );
   });
 
   test("clones object initial context", async () => {
     const initialCtx = { a: 1 };
 
-    const result = await executeMiddlewares([], initialCtx, returnContext);
+    const result = await runMiddlewares([], initialCtx, returnContext);
 
     expect(result).toEqual({ a: 1 });
     expect(result).not.toBe(initialCtx);
@@ -33,7 +41,7 @@ describe("executeMiddlewares", () => {
         return { ok: true };
       });
 
-      const result = await executeMiddlewares(
+      const result = await runMiddlewares(
         [{ kind: "legacy", middleware }],
         initialCtx,
         returnContext,
@@ -47,7 +55,7 @@ describe("executeMiddlewares", () => {
   test("executes middlewares sequentially and passes merged context", async () => {
     const order: string[] = [];
 
-    const result = await executeMiddlewares(
+    const result = await runMiddlewares(
       [
         {
           kind: "legacy",
@@ -77,7 +85,7 @@ describe("executeMiddlewares", () => {
   test("executes `.use()` middlewares sequentially via next", async () => {
     const order: string[] = [];
 
-    const result = await executeMiddlewares(
+    const result = await runMiddlewares(
       [
         {
           kind: "use",
@@ -108,7 +116,7 @@ describe("executeMiddlewares", () => {
   test("preserves mixed middleware order", async () => {
     const order: string[] = [];
 
-    const result = await executeMiddlewares(
+    const result = await runMiddlewares(
       [
         {
           kind: "legacy",
@@ -141,7 +149,7 @@ describe("executeMiddlewares", () => {
   });
 
   test("merges shallowly and later values override earlier ones", async () => {
-    const result = await executeMiddlewares(
+    const result = await runMiddlewares(
       [
         {
           kind: "legacy",
@@ -160,7 +168,7 @@ describe("executeMiddlewares", () => {
   });
 
   test("ignores non-object and falsy middleware returns", async () => {
-    const result = await executeMiddlewares(
+    const result = await runMiddlewares(
       [
         { kind: "legacy", middleware: () => undefined },
         { kind: "legacy", middleware: () => null },
@@ -177,7 +185,7 @@ describe("executeMiddlewares", () => {
   });
 
   test("returns context from the deepest next() call", async () => {
-    const result = await executeMiddlewares(
+    const result = await runMiddlewares(
       [
         {
           kind: "use",
@@ -196,7 +204,7 @@ describe("executeMiddlewares", () => {
   });
 
   test("allows calling next without params", async () => {
-    const result = await executeMiddlewares(
+    const result = await runMiddlewares(
       [
         {
           kind: "use",
@@ -212,7 +220,7 @@ describe("executeMiddlewares", () => {
 
   test("throws when a `.use()` middleware does not call next()", async () => {
     await expect(
-      executeMiddlewares(
+      runMiddlewares(
         [
           {
             kind: "use",
@@ -229,7 +237,7 @@ describe("executeMiddlewares", () => {
     const terminal = vi.fn(returnContext);
 
     await expect(
-      executeMiddlewares(
+      runMiddlewares(
         [
           {
             kind: "use",
@@ -250,7 +258,7 @@ describe("executeMiddlewares", () => {
     const neverCalled = vi.fn(() => ({ skipped: true }));
 
     await expect(
-      executeMiddlewares(
+      runMiddlewares(
         [
           {
             kind: "legacy",
@@ -277,7 +285,7 @@ describe("executeMiddlewares", () => {
 
   test("propagates rejected promises", async () => {
     await expect(
-      executeMiddlewares(
+      runMiddlewares(
         [
           {
             kind: "legacy",
@@ -289,9 +297,6 @@ describe("executeMiddlewares", () => {
       ),
     ).rejects.toThrow("reject boom");
   });
-});
-
-describe("createMiddlewareRunner", () => {
   test("normalizes context when no middlewares are registered", async () => {
     const runner = createMiddlewareRunner([]);
     const initialCtx = { a: 1 };

--- a/packages/server-act/src/internal/middleware.ts
+++ b/packages/server-act/src/internal/middleware.ts
@@ -46,7 +46,7 @@ function normalizeCtx(ctx?: unknown) {
   return ctx && typeof ctx === "object" ? { ...ctx } : {};
 }
 
-export type MiddlewareRunner = <TOutput>(
+type MiddlewareRunner = <TOutput>(
   initialCtx: unknown,
   terminal: MiddlewareTerminal<TOutput>,
 ) => Promise<TOutput>;
@@ -112,15 +112,4 @@ export function createMiddlewareRunner(
 
   return async (initialCtx, terminal) =>
     await run(normalizeCtx(initialCtx), terminal);
-}
-
-/**
- * Executes an array of middleware functions with the given initial context.
- */
-export async function executeMiddlewares<TOutput>(
-  middlewares: MiddlewareDef[],
-  initialCtx: unknown,
-  terminal: (ctx: Record<string, unknown>) => Promise<TOutput>,
-) {
-  return await createMiddlewareRunner(middlewares)(initialCtx, terminal);
 }

--- a/packages/server-act/src/internal/middleware.ts
+++ b/packages/server-act/src/internal/middleware.ts
@@ -54,6 +54,13 @@ type MiddlewareRunner = <TOutput>(
 const runTerminal: MiddlewareStep = async (ctx, terminal) =>
   await terminal(ctx);
 
+/**
+ * Builds a reusable middleware runner for a fixed middleware list.
+ *
+ * The returned runner normalizes the initial context for each invocation, keeps
+ * `.use()` middleware `next()` state isolated per call, and preserves the
+ * registration order while avoiding rebuilding the chain on every action run.
+ */
 export function createMiddlewareRunner(
   middlewares: readonly MiddlewareDef[],
 ): MiddlewareRunner {

--- a/packages/server-act/src/internal/middleware.ts
+++ b/packages/server-act/src/internal/middleware.ts
@@ -4,6 +4,12 @@ export type LegacyMiddlewareFunction<TContext, TReturn> = (params: {
 
 type MiddlewareContext = Record<string, unknown>;
 type Awaitable<T> = T | Promise<T>;
+type MiddlewareTerminal<TOutput> = (ctx: MiddlewareContext) => Promise<TOutput>;
+type MiddlewareStep = <TOutput>(
+  ctx: MiddlewareContext,
+  terminal: MiddlewareTerminal<TOutput>,
+) => Promise<TOutput>;
+
 declare const middlewareResultBrand: unique symbol;
 
 export type MiddlewareResult<
@@ -40,6 +46,74 @@ function normalizeCtx(ctx?: unknown) {
   return ctx && typeof ctx === "object" ? { ...ctx } : {};
 }
 
+export type MiddlewareRunner = <TOutput>(
+  initialCtx: unknown,
+  terminal: MiddlewareTerminal<TOutput>,
+) => Promise<TOutput>;
+
+const runTerminal: MiddlewareStep = async (ctx, terminal) =>
+  await terminal(ctx);
+
+export function createMiddlewareRunner(
+  middlewares: readonly MiddlewareDef[],
+): MiddlewareRunner {
+  if (middlewares.length === 0) {
+    return async (initialCtx, terminal) =>
+      await terminal(normalizeCtx(initialCtx));
+  }
+
+  let run = runTerminal;
+
+  for (let index = middlewares.length - 1; index >= 0; index--) {
+    const entry = middlewares[index];
+    if (!entry) continue;
+
+    const nextStep = run;
+
+    if (entry.kind === "legacy") {
+      run = async (ctx, terminal) => {
+        const result = await entry.middleware({ ctx });
+        const nextCtx =
+          result && typeof result === "object" ? { ...ctx, ...result } : ctx;
+        return await nextStep(nextCtx, terminal);
+      };
+      continue;
+    }
+
+    run = async <TOutput>(
+      ctx: MiddlewareContext,
+      terminal: MiddlewareTerminal<TOutput>,
+    ) => {
+      let nextCalled = false;
+      const result = await entry.middleware({
+        ctx,
+        next: async <TAddedContext extends MiddlewareContext = {}>(opts?: {
+          ctx?: TAddedContext;
+        }) => {
+          if (nextCalled) {
+            throw new Error(".use() middleware must call next() only once");
+          }
+          nextCalled = true;
+          const nextCtx = opts?.ctx ? { ...ctx, ...opts.ctx } : ctx;
+          return (await nextStep(
+            nextCtx,
+            terminal,
+          )) as MiddlewareResult<TAddedContext>;
+        },
+      });
+
+      if (!nextCalled) {
+        throw new Error(".use() middleware must call next()");
+      }
+
+      return result as TOutput;
+    };
+  }
+
+  return async (initialCtx, terminal) =>
+    await run(normalizeCtx(initialCtx), terminal);
+}
+
 /**
  * Executes an array of middleware functions with the given initial context.
  */
@@ -48,47 +122,5 @@ export async function executeMiddlewares<TOutput>(
   initialCtx: unknown,
   terminal: (ctx: Record<string, unknown>) => Promise<TOutput>,
 ) {
-  const executeAt = async (
-    index: number,
-    ctx: Record<string, unknown>,
-  ): Promise<TOutput> => {
-    const entry = middlewares[index];
-
-    if (!entry) {
-      return await terminal(ctx);
-    }
-
-    if (entry.kind === "legacy") {
-      const result = await entry.middleware({ ctx });
-      const nextCtx =
-        result && typeof result === "object" ? { ...ctx, ...result } : ctx;
-      return await executeAt(index + 1, nextCtx);
-    }
-
-    let nextCalled = false;
-    const result = await entry.middleware({
-      ctx,
-      next: async <TAddedContext extends MiddlewareContext = {}>(opts?: {
-        ctx?: TAddedContext;
-      }) => {
-        if (nextCalled) {
-          throw new Error(".use() middleware must call next() only once");
-        }
-        nextCalled = true;
-        const nextCtx = opts?.ctx ? { ...ctx, ...opts.ctx } : ctx;
-        return (await executeAt(
-          index + 1,
-          nextCtx,
-        )) as MiddlewareResult<TAddedContext>;
-      },
-    });
-
-    if (!nextCalled) {
-      throw new Error(".use() middleware must call next()");
-    }
-
-    return result as TOutput;
-  };
-
-  return await executeAt(0, normalizeCtx(initialCtx));
+  return await createMiddlewareRunner(middlewares)(initialCtx, terminal);
 }


### PR DESCRIPTION
## Summary

- Precompile middleware runners when `.action()` or `.stateAction()` is created, so the middleware chain shape is reused across calls.
- Skip middleware execution machinery entirely for actions without middleware.
- Remove the unused `executeMiddlewares()` wrapper now that production code uses `createMiddlewareRunner()` directly.
- Keep the middleware behavior tests by retargeting them to the real runner through a test-local helper.
- Add coverage for reusable runners and isolated per-call `next()` state.
- Add a patch changeset for `server-act`.

## Why

The previous runtime rebuilt and interpreted the middleware chain on every action invocation, even when no middleware was registered. This reduces per-call dispatch overhead while preserving the existing middleware behavior and validation flow.

After the runner refactor, `executeMiddlewares()` became production-dead code used only by tests, so the follow-up removes it instead of carrying a test-only wrapper in `middleware.ts`.

## Validation

- `pnpm --filter server-act test`
- `pnpm check`
- `pnpm changeset status --since=main`

Note: `pnpm changeset status --since=main` prints the local `term-size` CPU warning in this environment, but exits successfully and detects the patch bump.