### PR TITLE
Make form data path traversal iterative

### DIFF
--- a/.changeset/iterative-form-data-paths.md
+++ b/.changeset/iterative-form-data-paths.md
@@ -1,0 +1,5 @@
+---
+"server-act": patch
+---
+
+Process nested `FormData` field paths iteratively instead of recursively. This avoids allocating a sliced path at every nesting level, improves deeply nested form parsing performance, and prevents call stack overflows for unusually deep field names.

--- a/packages/server-act/src/utils.ts
+++ b/packages/server-act/src/utils.ts
@@ -26,43 +26,47 @@ function set(
   path: readonly string[],
   value: unknown,
 ): void {
-  const key = path[0];
-  assert(key != null);
+  assert(path.length > 0);
 
-  if (FORBIDDEN_KEYS.has(key)) {
-    throw new Error(`Unsafe form data key "${key}" is not allowed`);
-  }
+  let current = obj;
 
-  if (path.length > 1) {
-    const newPath = path.slice(1);
-    const nextKey = newPath[0];
-    assert(nextKey != null);
+  for (let index = 0; index < path.length; index++) {
+    const key = path[index];
+    assert(key != null);
 
-    if (obj[key] === undefined) {
-      obj[key] = isNumberString(nextKey) ? [] : {};
-    } else if (Array.isArray(obj[key]) && !isNumberString(nextKey)) {
-      obj[key] = Object.fromEntries(Object.entries(obj[key]));
-    } else if (!Array.isArray(obj[key]) && !isPlainObject(obj[key])) {
-      throw new Error(
-        `Conflicting form data key "${path.join(".")}": "${key}" is already a value`,
-      );
+    if (FORBIDDEN_KEYS.has(key)) {
+      throw new Error(`Unsafe form data key "${key}" is not allowed`);
     }
 
-    set(obj[key], newPath, value);
+    if (index < path.length - 1) {
+      const nextKey = path[index + 1];
+      assert(nextKey != null);
 
-    return;
-  }
+      if (current[key] === undefined) {
+        current[key] = isNumberString(nextKey) ? [] : {};
+      } else if (Array.isArray(current[key]) && !isNumberString(nextKey)) {
+        current[key] = Object.fromEntries(Object.entries(current[key]));
+      } else if (!Array.isArray(current[key]) && !isPlainObject(current[key])) {
+        throw new Error(
+          `Conflicting form data key "${path.slice(index).join(".")}": "${key}" is already a value`,
+        );
+      }
 
-  if (obj[key] === undefined) {
-    obj[key] = value;
-  } else if (Array.isArray(obj[key])) {
-    obj[key].push(value);
-  } else if (isPlainObject(obj[key])) {
-    throw new Error(
-      `Conflicting form data key "${key}": already holds a nested object`,
-    );
-  } else {
-    obj[key] = [obj[key], value];
+      current = current[key];
+      continue;
+    }
+
+    if (current[key] === undefined) {
+      current[key] = value;
+    } else if (Array.isArray(current[key])) {
+      current[key].push(value);
+    } else if (isPlainObject(current[key])) {
+      throw new Error(
+        `Conflicting form data key "${key}": already holds a nested object`,
+      );
+    } else {
+      current[key] = [current[key], value];
+    }
   }
 }
 

--- a/packages/server-act/tests/utils.test.ts
+++ b/packages/server-act/tests/utils.test.ts
@@ -215,6 +215,22 @@ describe("formDataToObject", () => {
     });
   });
 
+  test("should handle paths deeper than the call stack", () => {
+    const depth = 10_000;
+    const parts = Array.from({ length: depth }, (_, index) => `level${index}`);
+    const formData = new FormData();
+    formData.append(parts.join("."), "value");
+
+    const result = formDataToObject(formData);
+    let current: unknown = result;
+
+    for (const part of parts) {
+      current = (current as Record<string, unknown>)[part];
+    }
+
+    expect(current).toBe("value");
+  });
+
   test("should handle multiple values with nested paths", () => {
     const formData = new FormData();
     formData.append("users[0].tags", "frontend");


### PR DESCRIPTION
## What changed

- replace recursive `FormData` path traversal with an iterative cursor
- avoid allocating a sliced path at every nesting level
- add coverage for a 10,000-segment path

## Why

The recursive implementation performed progressively smaller `slice()` allocations and could overflow the JavaScript call stack for deeply nested field names. Iterative traversal keeps normal behavior while making path processing linear and stack-safe.

## Impact

Deeply nested form fields no longer fail with `RangeError`, and path parsing creates fewer temporary arrays.

## Validation

- `pnpm --filter server-act test` (103 tests passed)
- `pnpm check`
- `git diff --check`