### PR TITLE
Fix prototype-sensitive form keys

### DIFF
--- a/.changeset/own-property-safe-form-records.md
+++ b/.changeset/own-property-safe-form-records.md
@@ -1,0 +1,5 @@
+---
+"server-act": patch
+---
+
+Handle FormData fields and validation-error paths that match inherited object property names without corrupting values or throwing during error aggregation.

--- a/packages/server-act/src/internal/schema.test.ts
+++ b/packages/server-act/src/internal/schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vite-plus/test";
+import { getInputErrors } from "./schema";
+
+describe("getInputErrors", () => {
+  test.each(["toString", "hasOwnProperty", "constructor", "__proto__"])(
+    "should collect an issue for prototype-sensitive path `%s`",
+    (path) => {
+      const prototypeKeys = Reflect.ownKeys(Object.prototype);
+
+      const result = getInputErrors([
+        {
+          message: "Invalid value",
+          path: [path],
+        },
+      ]);
+
+      expect(Object.hasOwn(result.fieldErrors, path)).toBe(true);
+      expect(Object.keys(result.fieldErrors)).toContain(path);
+      expect(result.fieldErrors[path]).toEqual(["Invalid value"]);
+      expect(Object.getPrototypeOf(result.fieldErrors)).toBe(Object.prototype);
+      expect(Reflect.ownKeys(Object.prototype)).toEqual(prototypeKeys);
+    },
+  );
+
+  test("should append repeated issues for an inherited property name", () => {
+    const path: string = "toString";
+    const result = getInputErrors([
+      {
+        message: "First error",
+        path: [path],
+      },
+      {
+        message: "Second error",
+        path: [path],
+      },
+    ]);
+
+    expect(result.fieldErrors[path]).toEqual(["First error", "Second error"]);
+  });
+
+  test("should collect pathless issues as messages", () => {
+    const result = getInputErrors([
+      {
+        message: "Form is invalid",
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: ["Form is invalid"],
+      fieldErrors: {},
+    });
+    expect(Object.getPrototypeOf(result.fieldErrors)).toBe(Object.prototype);
+  });
+});

--- a/packages/server-act/src/internal/schema.ts
+++ b/packages/server-act/src/internal/schema.ts
@@ -16,12 +16,15 @@ export async function standardValidate<T extends StandardSchemaV1>(
 
 export function getInputErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>) {
   const messages: string[] = [];
-  const fieldErrors: Record<string, string[]> = {};
+  const fieldErrors = Object.create(null) as Record<string, string[]>;
   for (const issue of issues) {
     const dotPath = getDotPath(issue);
     if (dotPath) {
-      if (fieldErrors[dotPath]) {
-        fieldErrors[dotPath].push(issue.message);
+      const existingMessages = Object.hasOwn(fieldErrors, dotPath)
+        ? fieldErrors[dotPath]
+        : undefined;
+      if (existingMessages) {
+        existingMessages.push(issue.message);
       } else {
         fieldErrors[dotPath] = [issue.message];
       }
@@ -29,5 +32,8 @@ export function getInputErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>) {
       messages.push(issue.message);
     }
   }
-  return { messages, fieldErrors };
+  return {
+    messages,
+    fieldErrors: Object.fromEntries(Object.entries(fieldErrors)),
+  };
 }

--- a/packages/server-act/src/utils.ts
+++ b/packages/server-act/src/utils.ts
@@ -33,12 +33,14 @@ function set(
     throw new Error(`Unsafe form data key "${key}" is not allowed`);
   }
 
+  const hasKey = Object.hasOwn(obj, key);
+
   if (path.length > 1) {
     const newPath = path.slice(1);
     const nextKey = newPath[0];
     assert(nextKey != null);
 
-    if (obj[key] === undefined) {
+    if (!hasKey) {
       obj[key] = isNumberString(nextKey) ? [] : {};
     } else if (Array.isArray(obj[key]) && !isNumberString(nextKey)) {
       obj[key] = Object.fromEntries(Object.entries(obj[key]));
@@ -53,7 +55,7 @@ function set(
     return;
   }
 
-  if (obj[key] === undefined) {
+  if (!hasKey) {
     obj[key] = value;
   } else if (Array.isArray(obj[key])) {
     obj[key].push(value);

--- a/packages/server-act/tests/utils.test.ts
+++ b/packages/server-act/tests/utils.test.ts
@@ -374,6 +374,42 @@ describe("formDataToObject", () => {
     });
   });
 
+  describe("inherited property names", () => {
+    test("should handle a top-level inherited property name", () => {
+      const formData = new FormData();
+      formData.append("toString", "value");
+
+      const result = formDataToObject(formData);
+
+      expect(result).toEqual({ toString: "value" });
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    });
+
+    test("should handle a nested inherited property name", () => {
+      const formData = new FormData();
+      formData.append("toString.value", "nested");
+
+      const result = formDataToObject(formData);
+      const path: string = "toString";
+      const nested = result[path] as Record<string, unknown>;
+
+      expect(nested).toEqual({ value: "nested" });
+      expect(Object.getPrototypeOf(nested)).toBe(Object.prototype);
+    });
+
+    test("should collect repeated inherited property names", () => {
+      const formData = new FormData();
+      formData.append("hasOwnProperty", "first");
+      formData.append("hasOwnProperty", "second");
+
+      const result = formDataToObject(formData);
+
+      expect(result).toEqual({
+        hasOwnProperty: ["first", "second"],
+      });
+    });
+  });
+
   describe("prototype pollution", () => {
     test.each(["__proto__", "constructor", "prototype"])(
       "should reject top-level unsafe key `%s`",


### PR DESCRIPTION
## Summary

- Use own-property membership when constructing FormData output.
- Aggregate Standard Schema field errors safely for prototype-sensitive paths while returning ordinary objects.
- Add focused regressions and a patch changeset.

## Verification

- pnpm sherif
- pnpm build
- pnpm check
- pnpm test (111 tests)
- git diff --check