### PR TITLE
chore(ci): pin GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,21 +6,21 @@ on:
     branches: ["main"]
   merge_group:
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+permissions:
+  contents: read
 
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Vite Plus
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
         with:
           node-version-file: ".node-version"
           cache: true
@@ -30,9 +30,15 @@ jobs:
 
       - name: Build
         run: vp run build
+        env:
+          TURBO_TOKEN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.TURBO_TEAM || '' }}
 
       - name: Check
         run: vp check
 
       - name: Test
         run: vp run test
+        env:
+          TURBO_TOKEN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.TURBO_TEAM || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
     branches:
       - main
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Setup Vite Plus
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
         with:
           node-version-file: ".node-version"
           cache: true
@@ -30,10 +30,13 @@ jobs:
           vp i -g corepack
           corepack prepare --activate
           vpx turbo build --filter "./packages/*" build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
       - name: Create Release
         id: changeset
-        uses: changesets/action@v1.4.9
+        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1.4.9
         with:
           commit: "chore(release): 📦 version packages"
           title: "chore(release): 📦  version packages"


### PR DESCRIPTION
## Summary

- Pin checkout, setup-vp, and changesets/action to reviewed full commit SHAs.
- Declare least-privilege workflow token permissions and disable persisted CI checkout credentials.
- Restrict Turbo credentials to trusted main-branch build/test steps and the release build step.

## Verification

- Canonical Action tags re-resolved to the pinned commits
- Workflow YAML parsed successfully
- pnpm sherif
- pnpm build
- pnpm check
- pnpm test (102 tests)
- git diff --check