### PR TITLE
Test packed package exports in CI

### DIFF
--- a/.github/scripts/verify-package-pack.mjs
+++ b/.github/scripts/verify-package-pack.mjs
@@ -1,19 +1,22 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const packageDir = join(repoRoot, "packages/server-act");
 const packageManifestPath = join(packageDir, "package.json");
+const exampleManifestPath = join(repoRoot, "examples/nextjs/package.json");
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const requiredFiles = [
   "dist/index.mjs",
@@ -27,6 +30,28 @@ const requiredFiles = [
   "package.json",
   "README.md",
 ];
+const expectedExports = {
+  ".": {
+    import: {
+      types: "./dist/index.d.mts",
+      default: "./dist/index.mjs",
+    },
+    require: {
+      types: "./dist/index.d.cts",
+      default: "./dist/index.cjs",
+    },
+  },
+  "./utils": {
+    import: {
+      types: "./dist/utils.d.mts",
+      default: "./dist/utils.mjs",
+    },
+    require: {
+      types: "./dist/utils.d.cts",
+      default: "./dist/utils.cjs",
+    },
+  },
+};
 
 function getGitStatus() {
   return execFileSync(
@@ -41,6 +66,13 @@ function getGitStatus() {
 
 const manifestBefore = readFileSync(packageManifestPath);
 const sourceManifest = JSON.parse(manifestBefore.toString("utf8"));
+const exampleManifest = JSON.parse(readFileSync(exampleManifestPath, "utf8"));
+const typescriptVersion = exampleManifest.devDependencies?.typescript;
+assert.equal(
+  typeof typescriptVersion,
+  "string",
+  "examples/nextjs must declare a TypeScript development dependency",
+);
 const statusBefore = getGitStatus();
 const errors = [];
 let tempDir;
@@ -96,6 +128,200 @@ try {
       `packed tarball is missing ${requiredFile}`,
     );
   }
+
+  const tarballPath = join(tempDir, tarballs[0]);
+  const consumerDir = join(tempDir, "consumer");
+  mkdirSync(consumerDir);
+  writeFileSync(
+    join(consumerDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "server-act-package-smoke",
+        private: true,
+        type: "module",
+        dependencies: {
+          "server-act": pathToFileURL(tarballPath).href,
+        },
+        devDependencies: {
+          typescript: typescriptVersion,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  execFileSync(
+    npmCommand,
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--package-lock=false",
+      "--prefer-offline",
+    ],
+    {
+      cwd: consumerDir,
+      env: {
+        ...process.env,
+        npm_config_cache: join(tempDir, "npm-cache"),
+      },
+      stdio: "inherit",
+    },
+  );
+
+  const installedManifest = JSON.parse(
+    readFileSync(
+      join(consumerDir, "node_modules/server-act/package.json"),
+      "utf8",
+    ),
+  );
+  assert.equal(installedManifest.name, sourceManifest.name);
+  assert.equal(installedManifest.version, sourceManifest.version);
+  assert.equal(
+    installedManifest.dependencies?.["@standard-schema/spec"],
+    sourceManifest.dependencies["@standard-schema/spec"],
+  );
+  assert.equal(
+    installedManifest.dependencies?.["@standard-schema/utils"],
+    sourceManifest.dependencies["@standard-schema/utils"],
+  );
+  assert.deepEqual(installedManifest.exports["."], expectedExports["."]);
+  assert.deepEqual(
+    installedManifest.exports["./utils"],
+    expectedExports["./utils"],
+  );
+  assert.equal(
+    installedManifest.scripts?.prepack,
+    undefined,
+    "installed package must not contain a prepack lifecycle",
+  );
+
+  writeFileSync(
+    join(consumerDir, "smoke.mjs"),
+    `import assert from "node:assert/strict";
+import { createServerActMiddleware, serverAct } from "server-act";
+import { formDataToObject } from "server-act/utils";
+
+assert.equal(typeof serverAct, "object");
+assert.equal(typeof createServerActMiddleware, "function");
+assert.equal(typeof formDataToObject, "function");
+
+const middleware = createServerActMiddleware(({ next }) =>
+  next({ ctx: { mode: "esm" } }),
+);
+const action = serverAct
+  .use(middleware)
+  .action(async ({ ctx }) => ctx.mode);
+assert.equal(await action(), "esm");
+
+const formData = new FormData();
+formData.set("name", "Ada");
+assert.deepEqual(formDataToObject(formData), { name: "Ada" });
+`,
+  );
+  execFileSync(process.execPath, ["smoke.mjs"], {
+    cwd: consumerDir,
+    stdio: "inherit",
+  });
+  console.info("ESM root + utils runtime");
+
+  writeFileSync(
+    join(consumerDir, "smoke.cjs"),
+    `const assert = require("node:assert/strict");
+const { createServerActMiddleware, serverAct } = require("server-act");
+const { formDataToObject } = require("server-act/utils");
+
+async function main() {
+  assert.equal(typeof serverAct, "object");
+  assert.equal(typeof createServerActMiddleware, "function");
+  assert.equal(typeof formDataToObject, "function");
+
+  const middleware = createServerActMiddleware(({ next }) =>
+    next({ ctx: { mode: "cjs" } }),
+  );
+  const action = serverAct
+    .use(middleware)
+    .action(async ({ ctx }) => ctx.mode);
+  assert.equal(await action(), "cjs");
+
+  const formData = new FormData();
+  formData.set("name", "Grace");
+  assert.deepEqual(formDataToObject(formData), { name: "Grace" });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+`,
+  );
+  execFileSync(process.execPath, ["smoke.cjs"], {
+    cwd: consumerDir,
+    stdio: "inherit",
+  });
+  console.info("CJS root + utils runtime");
+
+  const typeConsumer = `import {
+  createServerActMiddleware,
+  serverAct,
+  type InputErrors,
+} from "server-act";
+import { formDataToObject } from "server-act/utils";
+
+const middleware = createServerActMiddleware(({ next }) =>
+  next({ ctx: { requestId: "request-1" } }),
+);
+const action = serverAct
+  .use(middleware)
+  .action(async ({ ctx }) => ctx.requestId);
+const actionResult: Promise<string> = action();
+const parsed: Record<string, unknown> = formDataToObject(new FormData());
+const inputErrors: InputErrors<{ name: string }> = {
+  messages: [],
+  fieldErrors: { name: ["Required"] },
+};
+
+void actionResult;
+void parsed;
+void inputErrors;
+`;
+  writeFileSync(join(consumerDir, "consumer.mts"), typeConsumer);
+  writeFileSync(join(consumerDir, "consumer.cts"), typeConsumer);
+  writeFileSync(
+    join(consumerDir, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          lib: ["ES2022", "DOM", "DOM.Iterable"],
+          skipLibCheck: false,
+          types: [],
+        },
+        include: ["consumer.mts", "consumer.cts"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  execFileSync(
+    process.execPath,
+    [
+      join(consumerDir, "node_modules/typescript/bin/tsc"),
+      "--project",
+      "tsconfig.json",
+    ],
+    {
+      cwd: consumerDir,
+      stdio: "inherit",
+    },
+  );
+  console.info("NodeNext .d.mts + .d.cts declarations");
 } catch (error) {
   errors.push(error);
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build
         run: vp run build
 
+      - name: Verify package artifact
+        run: vp run package:verify
+
       - name: Check
         run: vp check
 


### PR DESCRIPTION
## Summary

- Extend the package verifier to install the actual tarball in a disposable consumer.
- Exercise ESM and CJS root and utils exports plus NodeNext .d.mts and .d.cts declarations.
- Gate CI on the packed-artifact verifier immediately after Build.

## Stack

- Depends on #79; this PR intentionally targets the Plan 005 branch.

## Verification

- ESM root + utils runtime
- CJS root + utils runtime
- NodeNext .d.mts + .d.cts declarations
- pnpm sherif
- pnpm build
- pnpm package:verify
- pnpm check
- pnpm test (102 tests)
- git diff --check