### PR TITLE
Add output validation and transformation for server actions

### DIFF
--- a/.changeset/calm-actions-validate.md
+++ b/.changeset/calm-actions-validate.md
@@ -1,0 +1,6 @@
+---
+"server-act": minor
+---
+
+Add `.output()` for Standard Schema validation and transformation of values
+returned by `action` and `stateAction` handlers.

--- a/packages/server-act/README.md
+++ b/packages/server-act/README.md
@@ -46,7 +46,7 @@ export const sayHelloAction = serverAct
 import { sayHelloAction } from "./action";
 
 export const ClientComponent = () => {
-  const onClick = () => {
+  const onClick = async () => {
     const message = await sayHelloAction({ name: "John" });
     console.log(message); // Hello, John
   };
@@ -57,6 +57,46 @@ export const ClientComponent = () => {
     </div>
   );
 };
+```
+
+### Output Validation
+
+Use `.output()` to validate or transform the value returned by an action. Like
+`.input()`, it accepts any Standard Schema-compatible schema. The action handler
+returns the schema's input type, while callers receive its parsed output type.
+
+```ts
+"use server";
+
+import { serverAct } from "server-act";
+import { z } from "zod";
+
+export const getUserAction = serverAct
+  .input(z.string())
+  .output(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  )
+  .action(async ({ input: userId }) => {
+    return db.user.findUniqueOrThrow({ where: { id: userId } });
+  });
+```
+
+Invalid outputs throw a `SchemaError`, matching `.action()` input validation.
+Output validation also applies to values returned by `.stateAction()`. An output
+schema can be created from middleware context by passing a function:
+
+```ts
+const action = serverAct
+  .use(({ next }) => next({ ctx: { prefix: "user" } }))
+  .output(({ ctx }) =>
+    z.string().transform((value) => `${ctx.prefix}:${value}`),
+  )
+  .action(async () => "123");
+
+// Inferred as Promise<string>; resolves to "user:123".
 ```
 
 ### With Middleware

--- a/packages/server-act/src/index.ts
+++ b/packages/server-act/src/index.ts
@@ -25,13 +25,16 @@ function createServerActionBuilder(
   _input: UnsetMarker;
   _context: UnsetMarker;
   _inputErrorShape: UnsetMarker;
+  _output: UnsetMarker;
 }> {
   const _def: ActionBuilderDef<{
     _input: StandardSchemaV1;
-    _context: undefined;
+    _context: Record<string, unknown>;
     _inputErrorShape: unknown;
+    _output: StandardSchemaV1;
   }> = {
     input: undefined,
+    output: undefined,
     middleware: [],
     ...initDef,
   };
@@ -56,6 +59,8 @@ function createServerActionBuilder(
       })) as AnyActionBuilder["use"],
     input: (input) =>
       createNewServerActionBuilder({ ..._def, input }) as AnyActionBuilder,
+    output: (output) =>
+      createNewServerActionBuilder({ ..._def, output }) as never,
     action: (action) => {
       const middlewareRunner =
         _def.middleware.length > 0
@@ -66,16 +71,18 @@ function createServerActionBuilder(
         if (_def.input) {
           const inputSchema =
             typeof _def.input === "function"
-              ? await _def.input({ ctx: ctx as never })
+              ? await _def.input({ ctx })
               : _def.input;
           const result = await standardValidate(inputSchema, input);
           if (result.issues) {
             throw new SchemaError(result.issues);
           }
           // oxlint-disable-next-line typescript/no-explicit-any
-          return await action({ ctx, input: result.value as any });
+          const output = await action({ ctx, input: result.value as any });
+          return (await validateOutput(_def.output, ctx, output)) as never;
         }
-        return await action({ ctx, input: undefined });
+        const output = await action({ ctx, input: undefined });
+        return (await validateOutput(_def.output, ctx, output)) as never;
       };
 
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -99,31 +106,34 @@ function createServerActionBuilder(
         if (_def.input) {
           const inputSchema =
             typeof _def.input === "function"
-              ? await _def.input({ ctx: ctx as never })
+              ? await _def.input({ ctx })
               : _def.input;
           const result = await standardValidate(inputSchema, rawInput);
           if (result.issues) {
-            return await action({
+            const output = await action({
               ctx,
               prevState: prevState as never,
               rawInput: rawInput as never,
               inputErrors: getInputErrors(result.issues),
             });
+            return (await validateOutput(_def.output, ctx, output)) as never;
           }
-          return await action({
+          const output = await action({
             ctx,
             prevState: prevState as never,
             rawInput: rawInput as never,
             // oxlint-disable-next-line typescript/no-explicit-any
             input: result.value as any,
           });
+          return (await validateOutput(_def.output, ctx, output)) as never;
         }
-        return await action({
+        const output = await action({
           ctx,
           prevState: prevState as never,
           rawInput: rawInput as never,
           input: undefined,
         });
+        return (await validateOutput(_def.output, ctx, output)) as never;
       };
 
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -137,6 +147,27 @@ function createServerActionBuilder(
       };
     },
   };
+}
+
+async function validateOutput(
+  output:
+    | StandardSchemaV1
+    | ((params: {
+        ctx: Record<string, unknown>;
+      }) => Promise<StandardSchemaV1> | StandardSchemaV1)
+    | undefined,
+  ctx: Record<string, unknown>,
+  value: unknown,
+) {
+  if (!output) return value;
+
+  const outputSchema =
+    typeof output === "function" ? await output({ ctx }) : output;
+  const result = await standardValidate(outputSchema, value);
+  if (result.issues) {
+    throw new SchemaError(result.issues);
+  }
+  return result.value;
 }
 
 /**

--- a/packages/server-act/src/internal/types.ts
+++ b/packages/server-act/src/internal/types.ts
@@ -84,11 +84,77 @@ interface ActionParams<
   TInput = unknown,
   TContext = unknown,
   TInputErrorShape = unknown,
+  TOutput = unknown,
 > {
   _input: TInput;
   _context: TContext;
   _inputErrorShape: TInputErrorShape;
+  _output: TOutput;
 }
+
+type ActionOutput<TOutput, TFallback> = TOutput extends UnsetMarker
+  ? TFallback
+  : InferInputType<TOutput, "out">;
+
+type ActionHandlerOutput<TOutput, TFallback> = TOutput extends UnsetMarker
+  ? TFallback
+  : InferInputType<TOutput, "in">;
+
+type StateAction<TParams extends ActionParams> =
+  TParams["_output"] extends UnsetMarker
+    ? <TState, TPrevState = UnsetMarker>(
+        action: (
+          params: Prettify<
+            {
+              ctx: NormalizeContext<TParams["_context"]>;
+              prevState: RemoveUnsetMarker<TPrevState>;
+              rawInput: InferInputType<TParams["_input"], "in">;
+            } & (
+              | {
+                  input: InferInputType<TParams["_input"], "out">;
+                  inputErrors?: undefined;
+                }
+              | {
+                  input?: undefined;
+                  inputErrors: InputErrors<TParams["_inputErrorShape"]>;
+                }
+            )
+          >,
+        ) => Promise<TState>,
+      ) => (
+        prevState: TState | RemoveUnsetMarker<TPrevState>,
+        input: InferInputType<TParams["_input"], "in">,
+      ) => Promise<TState | RemoveUnsetMarker<TPrevState>>
+    : <TPrevState = UnsetMarker>(
+        action: (
+          params: Prettify<
+            {
+              ctx: NormalizeContext<TParams["_context"]>;
+              prevState:
+                | InferInputType<TParams["_output"], "out">
+                | RemoveUnsetMarker<TPrevState>;
+              rawInput: InferInputType<TParams["_input"], "in">;
+            } & (
+              | {
+                  input: InferInputType<TParams["_input"], "out">;
+                  inputErrors?: undefined;
+                }
+              | {
+                  input?: undefined;
+                  inputErrors: InputErrors<TParams["_inputErrorShape"]>;
+                }
+            )
+          >,
+        ) => Promise<InferInputType<TParams["_output"], "in">>,
+      ) => (
+        prevState:
+          | InferInputType<TParams["_output"], "out">
+          | RemoveUnsetMarker<TPrevState>,
+        input: InferInputType<TParams["_input"], "in">,
+      ) => Promise<
+        | InferInputType<TParams["_output"], "out">
+        | RemoveUnsetMarker<TPrevState>
+      >;
 
 export interface ActionBuilder<TParams extends ActionParams> {
   /**
@@ -110,6 +176,7 @@ export interface ActionBuilder<TParams extends ActionParams> {
       ? TNewContext
       : Prettify<TParams["_context"] & TNewContext>;
     _inputErrorShape: TParams["_inputErrorShape"];
+    _output: TParams["_output"];
   }>;
   /**
    * Registers middleware in the action pipeline.
@@ -127,6 +194,7 @@ export interface ActionBuilder<TParams extends ActionParams> {
       ? TNextContext
       : Prettify<NormalizeContext<TParams["_context"]> & TNextContext>;
     _inputErrorShape: TParams["_inputErrorShape"];
+    _output: TParams["_output"];
   }>;
   /**
    * Input validation for the action.
@@ -145,8 +213,27 @@ export interface ActionBuilder<TParams extends ActionParams> {
       _input: TParser;
       _context: TParams["_context"];
       _inputErrorShape: TInputErrorShape;
+      _output: TParams["_output"];
     }>,
     "input"
+  >;
+  /**
+   * Output validation for the action result.
+   */
+  output: <TParser extends StandardSchemaV1>(
+    output:
+      | ((params: {
+          ctx: NormalizeContext<TParams["_context"]>;
+        }) => Promise<TParser> | TParser)
+      | TParser,
+  ) => Omit<
+    ActionBuilder<{
+      _input: TParams["_input"];
+      _context: TParams["_context"];
+      _inputErrorShape: TParams["_inputErrorShape"];
+      _output: TParser;
+    }>,
+    "output"
   >;
   /**
    * Create an action.
@@ -155,48 +242,33 @@ export interface ActionBuilder<TParams extends ActionParams> {
     action: (params: {
       ctx: NormalizeContext<TParams["_context"]>;
       input: InferInputType<TParams["_input"], "out">;
-    }) => Promise<TOutput>,
+    }) => Promise<ActionHandlerOutput<TParams["_output"], TOutput>>,
   ) => SanitizeFunctionParam<
-    (input: InferInputType<TParams["_input"], "in">) => Promise<TOutput>
+    (
+      input: InferInputType<TParams["_input"], "in">,
+    ) => Promise<ActionOutput<TParams["_output"], TOutput>>
   >;
   /**
    * Create an action for React `useActionState`.
    */
-  stateAction: <TState, TPrevState = UnsetMarker>(
-    action: (
-      params: Prettify<
-        {
-          ctx: NormalizeContext<TParams["_context"]>;
-          prevState: RemoveUnsetMarker<TPrevState>;
-          rawInput: InferInputType<TParams["_input"], "in">;
-        } & (
-          | {
-              input: InferInputType<TParams["_input"], "out">;
-              inputErrors?: undefined;
-            }
-          | {
-              input?: undefined;
-              inputErrors: InputErrors<TParams["_inputErrorShape"]>;
-            }
-        )
-      >,
-    ) => Promise<TState>,
-  ) => (
-    prevState: TState | RemoveUnsetMarker<TPrevState>,
-    input: InferInputType<TParams["_input"], "in">,
-  ) => Promise<TState | RemoveUnsetMarker<TPrevState>>;
+  stateAction: StateAction<TParams>;
 }
 
 // oxlint-disable-next-line typescript/no-explicit-any
 export type AnyActionBuilder = ActionBuilder<any>;
 
-// oxlint-disable-next-line typescript/no-explicit-any
-export interface ActionBuilderDef<TParams extends ActionParams<any, any, any>> {
+export interface ActionBuilderDef<TParams extends ActionParams> {
   input:
     | ((params: {
         ctx: TParams["_context"];
       }) => Promise<TParams["_input"]> | TParams["_input"])
     | TParams["_input"]
+    | undefined;
+  output:
+    | ((params: {
+        ctx: TParams["_context"];
+      }) => Promise<TParams["_output"]> | TParams["_output"])
+    | TParams["_output"]
     | undefined;
   middleware: MiddlewareDef[];
 }

--- a/packages/server-act/tests/middleware.test.ts
+++ b/packages/server-act/tests/middleware.test.ts
@@ -273,23 +273,32 @@ describe("middleware", () => {
 
   describe("action wrapping", () => {
     test("should measure overall action execution time", async () => {
-      let duration = 0;
+      vi.useFakeTimers();
 
-      const action = serverAct
-        .use(async ({ next }) => {
-          const start = Date.now();
-          const result = await next({ ctx: { timed: true } });
-          duration = Date.now() - start;
-          return result;
-        })
-        .action(async ({ ctx }) => {
-          expect(ctx.timed).toBe(true);
-          await new Promise((resolve) => setTimeout(resolve, 10));
-          return "done";
-        });
+      try {
+        let duration = 0;
 
-      await expect(action()).resolves.toBe("done");
-      expect(duration).toBeGreaterThanOrEqual(10);
+        const action = serverAct
+          .use(async ({ next }) => {
+            const start = Date.now();
+            const result = await next({ ctx: { timed: true } });
+            duration = Date.now() - start;
+            return result;
+          })
+          .action(async ({ ctx }) => {
+            expect(ctx.timed).toBe(true);
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            return "done";
+          });
+
+        const result = action();
+        await vi.advanceTimersByTimeAsync(10);
+
+        await expect(result).resolves.toBe("done");
+        expect(duration).toBe(10);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     test("should allow middleware to observe action errors", async () => {

--- a/packages/server-act/tests/valibot.test.ts
+++ b/packages/server-act/tests/valibot.test.ts
@@ -62,6 +62,20 @@ describe("action", () => {
     await expect(action(1)).rejects.toThrowError();
   });
 
+  test("should validate and transform the output", async () => {
+    const action = serverAct
+      .output(
+        v.pipe(
+          v.string(),
+          v.transform((value) => value.length),
+        ),
+      )
+      .action(async () => Promise.resolve("bar"));
+
+    expectTypeOf(action).toEqualTypeOf<() => Promise<number>>();
+    await expect(action()).resolves.toBe(3);
+  });
+
   describe("middleware should be called once", () => {
     const middlewareSpy = vi.fn(
       createServerActMiddleware(({ next }) =>

--- a/packages/server-act/tests/zod.test.ts
+++ b/packages/server-act/tests/zod.test.ts
@@ -75,6 +75,37 @@ describe("action", () => {
     await expect(action(1)).rejects.toThrowError();
   });
 
+  test("should validate and transform the output", async () => {
+    const action = serverAct
+      .input(z.string())
+      .output(z.string().transform((value) => value.length))
+      .action(async ({ input }) => Promise.resolve(input));
+
+    expectTypeOf(action).toEqualTypeOf<(input: string) => Promise<number>>();
+    await expect(action("bar")).resolves.toBe(3);
+  });
+
+  test("should throw error if the output is invalid", async () => {
+    const runtimeInvalidAction = serverAct
+      .output(z.string())
+      // @ts-expect-error: Verify invalid values are also rejected at runtime.
+      .action(async () => Promise.resolve(123));
+
+    await expect(runtimeInvalidAction()).rejects.toThrowError();
+  });
+
+  test("should access middleware context in the output schema", async () => {
+    const action = serverAct
+      .use(({ next }) => next({ ctx: { prefix: "best" } }))
+      .output(({ ctx }) =>
+        z.string().transform((value) => `${ctx.prefix}-${value}`),
+      )
+      .action(async () => Promise.resolve("bar"));
+
+    expectTypeOf(action).toEqualTypeOf<() => Promise<string>>();
+    await expect(action()).resolves.toBe("best-bar");
+  });
+
   describe("middleware should be called once", () => {
     const middlewareSpy = vi.fn(
       createServerActMiddleware(({ next }) =>
@@ -135,6 +166,35 @@ describe("action", () => {
 });
 
 describe("stateAction", () => {
+  test("should validate and transform the output", async () => {
+    const action = serverAct
+      .output(z.string().transform((value) => value.length))
+      .stateAction(async ({ prevState }) => {
+        expectTypeOf(prevState).toEqualTypeOf<number | undefined>();
+        return Promise.resolve("bar");
+      });
+
+    expectTypeOf(action).toEqualTypeOf<
+      (
+        prevState: number | undefined,
+        input: undefined,
+      ) => Promise<number | undefined>
+    >();
+    await expect(action(undefined, undefined)).resolves.toBe(3);
+  });
+
+  test("should validate output from the input error branch", async () => {
+    const action = serverAct
+      .input(z.string())
+      .output(z.string().transform((value) => `validated:${value}`))
+      .stateAction(async ({ inputErrors }) =>
+        Promise.resolve(inputErrors ? "invalid" : "valid"),
+      );
+
+    // @ts-expect-error: Trigger the input validation branch at runtime.
+    await expect(action(undefined, 123)).resolves.toBe("validated:invalid");
+  });
+
   test("should able to create action without input", async () => {
     const action = serverAct.stateAction(async () => Promise.resolve("bar"));
 


### PR DESCRIPTION
## Summary

- Add `.output()` with Standard Schema validation and transformation.
- Support context-aware output schemas for `action` and `stateAction`.
- Update type inference, documentation, and changeset.
- Add coverage for Zod and Valibot outputs, invalid values, middleware context, and state actions.

## Testing

- Added unit tests covering output validation, transformation, type inference, and state-action branches.